### PR TITLE
Fix: Coroutine support

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/AnnotatedDataFetcherConfigurer.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/AnnotatedDataFetcherConfigurer.java
@@ -34,6 +34,7 @@ import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.KotlinDetector;
 import org.springframework.core.MethodIntrospector;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ParameterizedTypeReference;
@@ -162,6 +163,10 @@ public class AnnotatedDataFetcherConfigurer
 		this.argumentResolvers.addResolver(new ArgumentMapMethodArgumentResolver());
 		this.argumentResolvers.addResolver(new DataFetchingEnvironmentMethodArgumentResolver());
 		this.argumentResolvers.addResolver(new DataLoaderMethodArgumentResolver());
+
+		if (KotlinDetector.isKotlinPresent()) {
+			this.argumentResolvers.addResolver(new ContinuationHandlerMethodArgumentResolver());
+		}
 
 		// This works as a fallback, after all other resolvers
 		this.argumentResolvers.addResolver(new SourceMethodArgumentResolver());

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ContinuationHandlerMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ContinuationHandlerMethodArgumentResolver.java
@@ -1,0 +1,24 @@
+package org.springframework.graphql.data.method.annotation.support;
+
+import graphql.schema.DataFetchingEnvironment;
+import org.springframework.core.MethodParameter;
+import org.springframework.graphql.data.method.HandlerMethodArgumentResolver;
+
+/**
+ * No-op resolver for method arguments of type {@link kotlin.coroutines.Continuation}.
+ *
+ * @author Koen Punt
+ * @since 5.3
+ */
+public class ContinuationHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return "kotlin.coroutines.Continuation".equals(parameter.getParameterType().getName());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, DataFetchingEnvironment environment) throws Exception {
+        return null;
+    }
+}


### PR DESCRIPTION
The `kotlin.coroutines.Continuation` argument that is passed for suspended function was parsed as a graphql argument, which didn't work.
By adding an additional argument resolver the continuation is now resolved to `null`, which allows suspended functions for queries to work.

I'm unsure how to implement any test for this at the moment, because there's no kotlin code in this project (yet).

Fixes: #128 