### PR TITLE
Fix issue with lists not being converted to domain objects

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ArgumentMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ArgumentMethodArgumentResolver.java
@@ -111,10 +111,6 @@ public class ArgumentMethodArgumentResolver implements HandlerMethodArgumentReso
 			return null;
 		}
 
-		if (parameterType.isAssignableFrom(rawValue.getClass())) {
-			return returnValue(rawValue, parameterType);
-		}
-
 		if (rawValue instanceof List) {
 			Assert.isAssignable(List.class, parameterType,
 					"Argument '" + name + "' is a List while the @Argument method parameter is " + parameterType);
@@ -123,6 +119,8 @@ public class ArgumentMethodArgumentResolver implements HandlerMethodArgumentReso
 			if (valueList.isEmpty() || elementType.isAssignableFrom(valueList.get(0).getClass())) {
 				return returnValue(rawValue, parameterType);
 			}
+		} else if (parameterType.isAssignableFrom(rawValue.getClass())) {
+			return returnValue(rawValue, parameterType);
 		}
 
 		Object decodedValue = this.argumentConverter.convert(rawValue, parameter);


### PR DESCRIPTION
Because lists are assignable from lists, it didn't convert the objects in the list, which remained `LinkedHashMap`s. 

By always passing lists to the converter this issue is solved.