### PR TITLE
Add support for constructor binding on input arguments

### DIFF
--- a/spring-graphql/build.gradle
+++ b/spring-graphql/build.gradle
@@ -1,3 +1,6 @@
+plugins {
+	id 'org.jetbrains.kotlin.jvm' version '1.5.31'
+}
 description = "GraphQL Support for Spring Applications"
 
 dependencies {
@@ -34,11 +37,25 @@ dependencies {
 
 	testRuntimeOnly 'org.apache.logging.log4j:log4j-core'
 	testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
+	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 test {
 	useJUnitPlatform()
 	testLogging {
 		events "passed", "skipped", "failed"
+	}
+}
+repositories {
+	mavenCentral()
+}
+compileKotlin {
+	kotlinOptions {
+		jvmTarget = "1.8"
+	}
+}
+compileTestKotlin {
+	kotlinOptions {
+		jvmTarget = "1.8"
 	}
 }

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/ArgumentMethodArgumentResolverTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/ArgumentMethodArgumentResolverTests.java
@@ -87,6 +87,18 @@ class ArgumentMethodArgumentResolverTests {
 	}
 
 	@Test
+	void shouldResolveKotlinBeanArgument() throws Exception {
+		Method addBook = ClassUtils.getMethod(BookController.class, "ktAddBook", KotlinBookInput.class);
+		String payload = "{\"bookInput\": { \"name\": \"test name\", \"authorId\": 42} }";
+		DataFetchingEnvironment environment = initEnvironment(payload);
+		MethodParameter methodParameter = getMethodParameter(addBook, 0);
+		Object result = resolver.resolveArgument(methodParameter, environment);
+		assertThat(result).isNotNull().isInstanceOf(KotlinBookInput.class);
+		assertThat((KotlinBookInput) result).hasFieldOrPropertyWithValue("name", "test name")
+				.hasFieldOrPropertyWithValue("authorId", 42L);
+	}
+
+	@Test
 	void shouldResolveListOfJavaBeansArgument() throws Exception {
 		Method addBooks = ClassUtils.getMethod(BookController.class, "addBooks", List.class);
 		String payload = "{\"books\": [{ \"name\": \"first\", \"authorId\": 42}, { \"name\": \"second\", \"authorId\": 24}] }";
@@ -144,6 +156,11 @@ class ArgumentMethodArgumentResolverTests {
 
 		@MutationMapping
 		public Book addBook(@Argument BookInput bookInput) {
+			return null;
+		}
+
+		@MutationMapping
+		public Book ktAddBook(@Argument KotlinBookInput bookInput) {
 			return null;
 		}
 

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/KotlinBookInput.kt
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/KotlinBookInput.kt
@@ -1,0 +1,3 @@
+package org.springframework.graphql.data.method.annotation.support;
+
+data class KotlinBookInput(val name: String, val authorId: Long)


### PR DESCRIPTION
Implementation is partly taken from https://github.com/spring-projects/spring-framework/blob/958eb0f964ddef1ff1440fd10c5cb850f6ee96db/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ModelAttributeMethodArgumentResolver.java#L228-L260

Fixes #138 