### PR TITLE
Add OptionalInput type to allow explicit null value detection

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/OptionalInput.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/OptionalInput.java
@@ -1,0 +1,71 @@
+package org.springframework.graphql.data.method;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * Wrapper used to represent optionally defined input arguments that allows us to distinguish between undefined value, explicit NULL value
+ * and specified value.
+ */
+public class OptionalInput<T> {
+
+    public static<T> OptionalInput<T> defined(@Nullable T value) {
+        return new OptionalInput.Defined<>(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static<T> OptionalInput<T> undefined() {
+        return (OptionalInput<T>)new OptionalInput.Undefined();
+    }
+
+    /**
+     * Represents missing/undefined value.
+     */
+    public static class Undefined extends OptionalInput<Void> {
+        @Override
+        public boolean equals(Object obj) {
+            return obj.getClass() == this.getClass();
+        }
+
+        @Override
+        public int hashCode() {
+            return super.hashCode();
+        }
+    }
+
+    /**
+     * Wrapper holding explicitly specified value including NULL.
+     */
+    public static class Defined<T> extends OptionalInput<T> {
+        @Nullable
+        private final T value;
+
+        public Defined(@Nullable T value) {
+            this.value = value;
+        }
+
+        @Nullable
+        public T getValue() {
+            return value;
+        }
+
+        public Boolean isEmpty() {
+            return value == null;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Defined<?> defined = (Defined<?>) o;
+            if (isEmpty() == defined.isEmpty()) return true;
+            if (value == null) return false;
+            return value.equals(defined.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/GraphQlArgumentInstantiator.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/GraphQlArgumentInstantiator.java
@@ -87,7 +87,7 @@ class GraphQlArgumentInstantiator {
 					if (methodParam.getParameterType() == OptionalInput.class) {
 						args[i] = arguments.containsKey(paramName) ? OptionalInput.defined(null) : OptionalInput.undefined();
 					} else if(methodParam.isOptional()) {
-						args[i] = (methodParam.getParameterType() == Optional.class ? Optional.empty() : null);
+						args[i] = (methodParam.getParameterType() == Optional.class && arguments.containsKey(paramName) ? Optional.empty() : null);
 					}
 				}
 				else if (CollectionFactory.isApproximableCollectionType(value.getClass())) {

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/OptionalInputArgumentConversionService.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/OptionalInputArgumentConversionService.java
@@ -1,0 +1,27 @@
+package org.springframework.graphql.data.method.annotation.support;
+
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.graphql.data.method.OptionalInput;
+
+public class OptionalInputArgumentConversionService implements ConversionService {
+    @Override
+    public boolean canConvert(Class<?> sourceType, Class<?> targetType) {
+        return false;
+    }
+
+    @Override
+    public boolean canConvert(TypeDescriptor sourceType, TypeDescriptor targetType) {
+        return targetType.getType() == OptionalInput.class;
+    }
+
+    @Override
+    public <T> T convert(Object source, Class<T> targetType) {
+        return null;
+    }
+
+    @Override
+    public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+        return OptionalInput.defined(source);
+    }
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/OptionalInputArgumentConversionService.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/OptionalInputArgumentConversionService.java
@@ -4,6 +4,9 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.graphql.data.method.OptionalInput;
 
+import javax.swing.text.html.Option;
+import java.util.Optional;
+
 public class OptionalInputArgumentConversionService implements ConversionService {
     @Override
     public boolean canConvert(Class<?> sourceType, Class<?> targetType) {
@@ -12,7 +15,7 @@ public class OptionalInputArgumentConversionService implements ConversionService
 
     @Override
     public boolean canConvert(TypeDescriptor sourceType, TypeDescriptor targetType) {
-        return targetType.getType() == OptionalInput.class;
+        return targetType.getType() == OptionalInput.class || targetType.getType() == Optional.class;
     }
 
     @Override
@@ -22,6 +25,10 @@ public class OptionalInputArgumentConversionService implements ConversionService
 
     @Override
     public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
-        return OptionalInput.defined(source);
+        if (targetType.getType() == Optional.class) {
+            return Optional.of(source);
+        } else {
+            return OptionalInput.defined(source);
+        }
     }
 }

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/ArgumentMethodArgumentResolverTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/ArgumentMethodArgumentResolverTests.java
@@ -20,6 +20,7 @@ package org.springframework.graphql.data.method.annotation.support;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -37,6 +38,8 @@ import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.ClassUtils;
+
+import javax.annotation.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -85,7 +88,7 @@ class ArgumentMethodArgumentResolverTests {
 		assertThat(result).isNotNull().isInstanceOf(BookInput.class);
 		assertThat((BookInput) result).hasFieldOrPropertyWithValue("name", "test name")
 				.hasFieldOrPropertyWithValue("authorId", 42L)
-				.hasFieldOrPropertyWithValue("notes", OptionalInput.undefined());
+				.hasFieldOrPropertyWithValue("notes", null);
 	}
 
 	@Test
@@ -99,7 +102,7 @@ class ArgumentMethodArgumentResolverTests {
 		assertThat((BookInput) result)
 				.hasFieldOrPropertyWithValue("name", "test name")
 				.hasFieldOrPropertyWithValue("authorId", 42L)
-				.hasFieldOrPropertyWithValue("notes", OptionalInput.defined("Hello"));
+				.hasFieldOrPropertyWithValue("notes", Optional.of("Hello"));
 	}
 
 	@Test
@@ -113,7 +116,7 @@ class ArgumentMethodArgumentResolverTests {
 		assertThat((BookInput) result)
 				.hasFieldOrPropertyWithValue("name", "test name")
 				.hasFieldOrPropertyWithValue("authorId", 42L)
-				.hasFieldOrPropertyWithValue("notes", OptionalInput.defined(null));
+				.hasFieldOrPropertyWithValue("notes", Optional.empty());
 	}
 
 	@Test
@@ -127,7 +130,7 @@ class ArgumentMethodArgumentResolverTests {
 		assertThat((KotlinBookInput) result)
 				.hasFieldOrPropertyWithValue("name", "test name")
 				.hasFieldOrPropertyWithValue("authorId", 42L)
-				.hasFieldOrPropertyWithValue("notes", OptionalInput.undefined());
+				.hasFieldOrPropertyWithValue("notes", null);
 	}
 
 	@Test
@@ -141,7 +144,7 @@ class ArgumentMethodArgumentResolverTests {
 		assertThat((KotlinBookInput) result)
 				.hasFieldOrPropertyWithValue("name", "test name")
 				.hasFieldOrPropertyWithValue("authorId", 42L)
-				.hasFieldOrPropertyWithValue("notes", OptionalInput.defined("Hello"));
+				.hasFieldOrPropertyWithValue("notes", Optional.of("Hello"));
 	}
 
 	@Test
@@ -155,7 +158,7 @@ class ArgumentMethodArgumentResolverTests {
 		assertThat((KotlinBookInput) result)
 				.hasFieldOrPropertyWithValue("name", "test name")
 				.hasFieldOrPropertyWithValue("authorId", 42L)
-				.hasFieldOrPropertyWithValue("notes", OptionalInput.defined(null));
+				.hasFieldOrPropertyWithValue("notes", Optional.empty());
 	}
 
 	@Test
@@ -217,7 +220,8 @@ class ArgumentMethodArgumentResolverTests {
 
 		Long authorId;
 
-		OptionalInput<String> notes = OptionalInput.undefined();
+		@Nullable
+		Optional<String> notes = null;
 
 		public String getName() {
 			return this.name;
@@ -235,12 +239,13 @@ class ArgumentMethodArgumentResolverTests {
 			this.authorId = authorId;
 		}
 
-		public OptionalInput<String> getNotes() {
+		@Nullable
+		public Optional<String> getNotes() {
 			return this.notes;
 		}
 
-		public void setNotes(OptionalInput<String> notes) {
-			this.notes = (notes == null) ? OptionalInput.defined(null) : notes;
+		public void setNotes(@Nullable Optional<String> notes) {
+			this.notes = notes;
 		}
 	}
 

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/KotlinBookInput.kt
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/KotlinBookInput.kt
@@ -1,0 +1,8 @@
+package org.springframework.graphql.data.method.annotation.support;
+
+import org.springframework.graphql.data.method.OptionalInput
+
+data class KotlinBookInput(
+    val name: String, val authorId: Long,
+    val notes: OptionalInput<String?>
+)

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/KotlinBookInput.kt
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/KotlinBookInput.kt
@@ -1,8 +1,8 @@
 package org.springframework.graphql.data.method.annotation.support;
 
-import org.springframework.graphql.data.method.OptionalInput
+import java.util.Optional
 
 data class KotlinBookInput(
     val name: String, val authorId: Long,
-    val notes: OptionalInput<String?>
+    val notes: Optional<String?>?
 )


### PR DESCRIPTION
In graphql there's a difference between a null passed as input, and not providing the input value at all.

Inspired by the type that graphql-kotlin provided, I've introduced an `OptionalInput` wrapper, which can be used to distinguish between explicit null values and absent values.

Builds upon #139 