### PR TITLE
Recursively instantiate arguments

### DIFF
--- a/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/GraphQlArgumentInstantiatorTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/GraphQlArgumentInstantiatorTests.java
@@ -93,6 +93,16 @@ class GraphQlArgumentInstantiatorTests {
 		assertThat(result.getItems()).hasSize(2).extracting("name").containsExactly("first", "second");
 	}
 
+	@Test
+	void shouldInstantiatePrimaryConstructorNestedBeanLists() throws Exception {
+		String payload = "{\"nestedList\": { \"items\": [ {\"name\": \"first\"}, {\"name\": \"second\"}] } }";
+		DataFetchingEnvironment environment = initEnvironment(payload);
+		PrimaryConstructorNestedList result = instantiator.instantiate(PrimaryConstructorNestedList.class, environment.getArgument("nestedList"));
+
+		assertThat(result).isNotNull().isInstanceOf(PrimaryConstructorNestedList.class);
+		assertThat(result.getItems()).hasSize(2).extracting("name").containsExactly("first", "second");
+	}
+
 	private DataFetchingEnvironment initEnvironment(String jsonPayload) throws JsonProcessingException {
 		Map<String, Object> arguments = this.mapper.readValue(jsonPayload, new TypeReference<Map<String, Object>>() {
 		});
@@ -144,6 +154,19 @@ class GraphQlArgumentInstantiatorTests {
 
 		public void setItems(List<Item> items) {
 			this.items = items;
+		}
+	}
+
+	static class PrimaryConstructorNestedList {
+
+		final List<Item> items;
+
+		public PrimaryConstructorNestedList(List<Item> items) {
+			this.items = items;
+		}
+
+		public List<Item> getItems() {
+			return items;
 		}
 	}
 


### PR DESCRIPTION
Every list that is encountered is recursively passed to the instantiator, instead of trying to convert the list using the databinder.

This also fixes #145, by directly accessing the arguments from the arguments map, instead of the mapped propertyvalues used for the DataBinder.