### PR TITLE
bypass arguments parsing when target type is a map

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ArgumentMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ArgumentMethodArgumentResolver.java
@@ -74,8 +74,17 @@ public class ArgumentMethodArgumentResolver implements HandlerMethodArgumentReso
 		if (CollectionFactory.isApproximableCollectionType(rawValue.getClass())) {
 			Assert.isAssignable(Collection.class, parameterType.getType(),
 					"Argument '" + name + "' is a Collection while the @Argument method parameter is " + parameterType.getType());
+
+			if (parameterType.getElementTypeDescriptor().getType() == Map.class) {
+				return rawValue;
+			}
+
 			Class<?> elementType = parameterType.getElementTypeDescriptor().getType();
 			return this.instantiator.instantiateCollection(elementType, (Collection<Object>) rawValue);
+		}
+
+		if (parameterType.isMap()) {
+			return rawValue;
 		}
 
 		MethodParameter nestedParameter = parameter.nestedIfOptional();


### PR DESCRIPTION
This allows for unparsed forwarding of graphql arguments, in the case something application specific has to be done with the arguments.

The library already supports passing all of the input as a map, by specifying an argument as `@Argument args: Map<String, ?>`. 

This PR adds support for doing this for individual arguments.

For example to distinguish between unspecified and `null` values;

```graphql
input SomeInput {
  name: String
}

type Mutation {
  perform(input: SomeInput!): ...
}
```

Kotlin:

```kt
@MutationMapping
fun perform(@Argument input: Map<String, Any?>): ... {
  if (input.contains("name")) {
    if (input["name"] == null) {
      // throw error
    } else {
      // ...
    }
  }
}
```

Java:

```java
@MutationMapping
... perform(@Argument Map<String, ?> input) {
  if (input.containsKey("name")) {
    if (input["name"] == null) {
      // throw error
    } else {
      // ...
    }
  }
}
```
