### PR TITLE
Allow customising/replacing the Executable Schema creation

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/execution/GraphQlSource.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/execution/GraphQlSource.java
@@ -18,6 +18,7 @@ package org.springframework.graphql.execution;
 
 import java.io.File;
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
 import graphql.GraphQL;
@@ -124,6 +125,14 @@ public interface GraphQlSource {
 		 * @return the current builder
 		 */
 		Builder configureGraphQl(Consumer<GraphQL.Builder> configurer);
+
+		/**
+		 * Provide a custom factory for creating an executable {@link GraphQLSchema} given
+		 * a {@link TypeDefinitionRegistry} and a {@link RuntimeWiring}
+		 * @param schemaFactory the schema factory
+		 * @return the current builder
+		 */
+		Builder schemaFactory(BiFunction<TypeDefinitionRegistry, RuntimeWiring, GraphQLSchema> schemaFactory);
 
 		/**
 		 * Build the {@link GraphQlSource}.


### PR DESCRIPTION
Hello,

I am proposing this change to the way spring-graphql creates the executable schema. The change allows registering a bean (`GraphQlSchemaFactory`) which allows users to customise or replace the way spring-graphql creates the executable schema after it has finished creating the Type Registry and Runtime Wiring.

My main use case is to use [Apollo's Federation Library](https://github.com/apollographql/federation-jvm) which takes over responsibility for creating the executable schema as it has its own modifications it makes to it, but needs the Type Registry and Runtime Wiring first. 