### PR TITLE
Cannot bind input argument with nested beans and primary constructors

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/GraphQlArgumentInstantiator.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/GraphQlArgumentInstantiator.java
@@ -89,7 +89,9 @@ class GraphQlArgumentInstantiator {
 					Class<?> elementType = typeDescriptor.getElementTypeDescriptor().getType();
 					args[i] = instantiateCollection(elementType, (Collection<Object>) value);
 				}
-				else {
+				else if (value instanceof Map) {
+					args[i] = this.instantiate((Map<String, Object>) value, methodParam.getParameterType());
+				} else {
 					args[i] = this.converter.convertIfNecessary(value, paramTypes[i], methodParam);
 				}
 			}

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/GraphQlArgumentInstantiatorTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/GraphQlArgumentInstantiatorTests.java
@@ -103,6 +103,17 @@ class GraphQlArgumentInstantiatorTests {
 		assertThat(result.getItems()).hasSize(2).extracting("name").containsExactly("first", "second");
 	}
 
+	@Test
+	void shouldInstantiateComplexNestedBean() throws Exception {
+		String payload = "{\"complex\": { \"item\": {\"name\": \"Item name\"}, \"name\": \"Hello\" } }";
+		DataFetchingEnvironment environment = initEnvironment(payload);
+		PrimaryConstructorComplexInput result = instantiator.instantiate(environment.getArgument("complex"), PrimaryConstructorComplexInput.class);
+
+		assertThat(result).isNotNull().isInstanceOf(PrimaryConstructorComplexInput.class);
+		assertThat(result.item.name).isEqualTo("Item name");
+		assertThat(result.name).isEqualTo("Hello");
+	}
+
 	private DataFetchingEnvironment initEnvironment(String jsonPayload) throws JsonProcessingException {
 		Map<String, Object> arguments = this.mapper.readValue(jsonPayload, new TypeReference<Map<String, Object>>() {
 		});
@@ -180,6 +191,25 @@ class GraphQlArgumentInstantiatorTests {
 
 		public void setName(String name) {
 			this.name = name;
+		}
+	}
+
+	static class PrimaryConstructorComplexInput {
+		final String name;
+
+		final Item item;
+
+		public PrimaryConstructorComplexInput(String name, Item item) {
+			this.name = name;
+			this.item = item;
+		}
+
+		public String getName() {
+			return this.name;
+		}
+
+		public Item getItem() {
+			return item;
 		}
 	}
 	


### PR DESCRIPTION
Arguments with nested beans with a primary constructor (e.g. kotlin data classes) were not instantiated correctly.

By recursively calling `instantiate` on map types this works as expected.