### PR TITLE
Fix typo in index.adoc

### DIFF
--- a/spring-graphql-docs/src/docs/asciidoc/index.adoc
+++ b/spring-graphql-docs/src/docs/asciidoc/index.adoc
@@ -778,7 +778,7 @@ Batch mapping methods can return:
 | A sequence of batch loaded objects that must be in the same order as the source/parent
   objects passed into the method.
 
-| `Map<K,V>`, `Flux<V>`
+| `Map<K,V>`, `List<V>`
 | Imperative variants, e.g. without remote calls to make.
 
 |===


### PR DESCRIPTION
It should be `List` here?