### PR TITLE
GraphQlTester: allow variables to have a `null` value

### DIFF
--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
@@ -108,7 +108,7 @@ class DefaultGraphQlTester implements GraphQlTester {
 		}
 
 		@Override
-		public DefaultRequestSpec variable(String name, Object value) {
+		public DefaultRequestSpec variable(String name, @Nullable Object value) {
 			addVariable(name, value);
 			return this;
 		}

--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultWebGraphQlTester.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultWebGraphQlTester.java
@@ -117,7 +117,7 @@ class DefaultWebGraphQlTester implements WebGraphQlTester {
 		}
 
 		@Override
-		public WebRequestSpec variable(String name, Object value) {
+		public WebRequestSpec variable(String name, @Nullable Object value) {
 			addVariable(name, value);
 			return this;
 		}

--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/GraphQlTester.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/GraphQlTester.java
@@ -172,7 +172,7 @@ public interface GraphQlTester {
 		 * @param value the variable value
 		 * @return this request spec
 		 */
-		T variable(String name, Object value);
+		T variable(String name, @Nullable Object value);
 
 	}
 

--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/GraphQlTesterRequestSpecSupport.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/GraphQlTesterRequestSpecSupport.java
@@ -49,7 +49,7 @@ class GraphQlTesterRequestSpecSupport {
 		this.operationName = name;
 	}
 
-	protected void addVariable(String name, Object value) {
+	protected void addVariable(String name, @Nullable Object value) {
 		this.variables.put(name, value);
 	}
 

--- a/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
+++ b/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
@@ -179,6 +179,7 @@ public class GraphQlTesterTests {
 				.operationName("HeroNameAndFriends")
 				.variable("episode", "JEDI")
 				.variable("foo", "bar")
+				.variable("optional", null)
 				.execute();
 
 		spec.path("hero").entity(MovieCharacter.class).isEqualTo(MovieCharacter.create("R2-D2"));
@@ -186,9 +187,10 @@ public class GraphQlTesterTests {
 		RequestInput input = this.inputCaptor.getValue();
 		assertThat(input.getQuery()).contains(query);
 		assertThat(input.getOperationName()).isEqualTo("HeroNameAndFriends");
-		assertThat(input.getVariables()).hasSize(2);
+		assertThat(input.getVariables()).hasSize(3);
 		assertThat(input.getVariables()).containsEntry("episode", "JEDI");
 		assertThat(input.getVariables()).containsEntry("foo", "bar");
+		assertThat(input.getVariables()).containsEntry("optional", null);
 	}
 
 	@Test


### PR DESCRIPTION
There's a difference between an explicit `null` value and omitting an argument.

By allowing the variables to have a `null` value both can be tested.