### PR TITLE
Support integration with Sentry exception handling

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/execution/ExceptionResolversExceptionHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/execution/ExceptionResolversExceptionHandler.java
@@ -41,7 +41,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Rossen Stoyanchev
  */
-class ExceptionResolversExceptionHandler implements DataFetcherExceptionHandler {
+public class ExceptionResolversExceptionHandler implements DataFetcherExceptionHandler {
 
 	private static final Log logger = LogFactory.getLog(ExceptionResolversExceptionHandler.class);
 
@@ -51,7 +51,7 @@ class ExceptionResolversExceptionHandler implements DataFetcherExceptionHandler 
 	 * Create an instance.
 	 * @param resolvers the resolvers to use
 	 */
-	ExceptionResolversExceptionHandler(List<DataFetcherExceptionResolver> resolvers) {
+	public ExceptionResolversExceptionHandler(List<DataFetcherExceptionResolver> resolvers) {
 		Assert.notNull(resolvers, "'resolvers' is required");
 		this.resolvers = new ArrayList<>(resolvers);
 	}


### PR DESCRIPTION
With the latest version of the sentry-java library [support for graphql-java](https://github.com/getsentry/sentry-java/pull/1777) has been added.

The implementation requires the use of a delegating `SentryDataFetcherExceptionHandler`, which then invokes the delegate method after capturing the exception for registration by Sentry.

By making `ExceptionResolversExceptionHandler` public, it can be used as a delegate.

I would expect something like this to work;

```kt
@Bean
fun sentryExceptionHandler(exceptionResolvers: List<DataFetcherExceptionResolver>): DataFetcherExceptionHandler {
  return SentryDataFetcherExceptionHandler(ExceptionResolversExceptionHandler(exceptionResolvers));
}
```