### PR TITLE
Change error message payload to be an array as defined in graphql-ws

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandler.java
@@ -246,7 +246,10 @@ public class GraphQlWebSocketHandler implements WebSocketHandler {
 								.message(ex.getMessage())
 								.build()
 								.toSpecification();
-						return Mono.just(encode(session, id, MessageType.ERROR, errorMap));
+
+						// Payload needs to be an array
+					    //  see: https://github.com/enisdenjo/graphql-ws/blob/master/docs/interfaces/common.ErrorMessage.md#payload
+						return Mono.just(encode(session, id, MessageType.ERROR, Collections.singletonList(errorMap)));
 				});
 	}
 

--- a/spring-graphql/src/main/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandler.java
@@ -248,7 +248,7 @@ public class GraphQlWebSocketHandler implements WebSocketHandler {
 								.toSpecification();
 
 						// Payload needs to be an array
-					    //  see: https://github.com/enisdenjo/graphql-ws/blob/master/docs/interfaces/common.ErrorMessage.md#payload
+						//  see: https://github.com/enisdenjo/graphql-ws/blob/master/docs/interfaces/common.ErrorMessage.md#payload
 						return Mono.just(encode(session, id, MessageType.ERROR, Collections.singletonList(errorMap)));
 				});
 	}

--- a/spring-graphql/src/main/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandler.java
@@ -262,8 +262,8 @@ public class GraphQlWebSocketHandler extends TextWebSocketHandler implements Sub
 								.toSpecification();
 
 						// Payload needs to be an array
-					    //  see: https://github.com/enisdenjo/graphql-ws/blob/master/docs/interfaces/common.ErrorMessage.md#payload
-					    return Mono.just(encode(id, MessageType.ERROR, Collections.singletonList(errorMap)));
+						//  see: https://github.com/enisdenjo/graphql-ws/blob/master/docs/interfaces/common.ErrorMessage.md#payload
+						return Mono.just(encode(id, MessageType.ERROR, Collections.singletonList(errorMap)));
 				});
 	}
 

--- a/spring-graphql/src/main/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandler.java
@@ -260,7 +260,10 @@ public class GraphQlWebSocketHandler extends TextWebSocketHandler implements Sub
 						String message = ex.getMessage();
 						Map<String, Object> errorMap = GraphqlErrorBuilder.newError().errorType(errorType).message(message).build()
 								.toSpecification();
-						return Mono.just(encode(id, MessageType.ERROR, errorMap));
+
+						// Payload needs to be an array
+					    //  see: https://github.com/enisdenjo/graphql-ws/blob/master/docs/interfaces/common.ErrorMessage.md#payload
+					    return Mono.just(encode(id, MessageType.ERROR, Collections.singletonList(errorMap)));
 				});
 	}
 

--- a/spring-graphql/src/test/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandlerTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandlerTests.java
@@ -26,6 +26,8 @@ import java.util.function.BiConsumer;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
+import org.springframework.graphql.GraphQlSetup;
+import org.springframework.graphql.web.WebGraphQlHandler;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
@@ -243,6 +245,60 @@ public class GraphQlWebSocketHandlerTests extends WebSocketHandlerTestSupport {
 				.consumeNextWith((message) -> assertMessageType(message, "next"))
 				.then(() -> input.tryEmitNext(toWebSocketMessage(completeMessage)))
 				.verifyTimeout(Duration.ofMillis(500));
+	}
+
+	@Test
+	void errorMessagePayloadIsCorrectArray() {
+		final String GREETING_QUERY = "{" +
+				"\"id\":\"" + SUBSCRIPTION_ID + "\"," +
+				"\"type\":\"subscribe\"," +
+				"\"payload\":{\"query\": \"" +
+				"  subscription TestTypenameSubscription {" +
+				"    greeting" +
+				"  }\"}" +
+				"}";
+
+		WebGraphQlHandler initHandler = GraphQlSetup.schemaContent("" +
+						"type Subscription { greeting: String! }" +
+						"type Query { greetingUnused: String! }")
+				.subscriptionFetcher("greeting", env -> Flux.just("a", null, "b"))
+				.webInterceptor()
+				.toWebGraphQlHandler();
+
+		GraphQlWebSocketHandler handler = new GraphQlWebSocketHandler(
+				initHandler,
+				ServerCodecConfigurer.create(),
+				Duration.ofSeconds(60));
+
+		TestWebSocketSession session = new TestWebSocketSession(Flux.just(
+				toWebSocketMessage("{\"type\":\"connection_init\"}"),
+				toWebSocketMessage(GREETING_QUERY)));
+		handler.handle(session).block();
+
+		StepVerifier.create(session.getOutput())
+				.consumeNextWith((message) -> assertMessageType(message, "connection_ack"))
+				.consumeNextWith((message) -> assertThat(decode(message))
+						.hasSize(3)
+						.containsEntry("id", SUBSCRIPTION_ID)
+						.containsEntry("type", "next")
+						.extractingByKey("payload", as(InstanceOfAssertFactories.map(String.class, Object.class)))
+						.extractingByKey("data", as(InstanceOfAssertFactories.map(String.class, Object.class)))
+						.containsEntry("greeting", "a"))
+				.consumeNextWith((message) -> assertThat(decode(message))
+						.hasSize(3)
+						.containsEntry("id", SUBSCRIPTION_ID)
+						.containsEntry("type", "error")
+						.hasEntrySatisfying("payload", payload -> assertThat(payload)
+								.asList()
+								.hasSize(1)
+								.allSatisfy(theError -> assertThat(theError)
+										.asInstanceOf(InstanceOfAssertFactories.map(String.class, Object.class))
+										.hasSize(3)
+										.hasEntrySatisfying("locations", loc -> assertThat(loc).asList().isEmpty())
+										.hasEntrySatisfying("message", msg -> assertThat(msg).asString().contains("null"))
+										.extractingByKey("extensions", as(InstanceOfAssertFactories.map(String.class, Object.class)))
+										.containsEntry("classification", "DataFetchingException"))))
+				.verifyComplete();
 	}
 
 	private TestWebSocketSession handle(Flux<WebSocketMessage> input, WebInterceptor... interceptors) {

--- a/spring-graphql/src/test/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandlerTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandlerTests.java
@@ -29,6 +29,9 @@ import java.util.function.Consumer;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
+import org.springframework.graphql.GraphQlSetup;
+import org.springframework.graphql.web.WebGraphQlHandler;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -247,6 +250,57 @@ public class GraphQlWebSocketHandlerTests extends WebSocketHandlerTestSupport {
 				.consumeNextWith((message) -> assertMessageType(message, "next"))
 				.then(() -> messageSender.accept(completeMessage))
 				.verifyTimeout(Duration.ofMillis(500));
+	}
+
+	@Test
+	void errorMessagePayloadIsCorrectArray() throws Exception {
+		final String GREETING_QUERY = "{" +
+				"\"id\":\"" + SUBSCRIPTION_ID + "\"," +
+				"\"type\":\"subscribe\"," +
+				"\"payload\":{\"query\": \"" +
+				"  subscription TestTypenameSubscription {" +
+				"    greeting" +
+				"  }\"}" +
+				"}";
+
+		WebGraphQlHandler initHandler = GraphQlSetup.schemaContent("" +
+						"type Subscription { greeting: String! }" +
+						"type Query { greetingUnused: String! }")
+				.subscriptionFetcher("greeting", env -> Flux.just("a", null, "b"))
+				.webInterceptor()
+				.toWebGraphQlHandler();
+
+		GraphQlWebSocketHandler handler = new GraphQlWebSocketHandler(initHandler, converter, Duration.ofSeconds(60));
+
+		handle(handler,
+				new TextMessage("{\"type\":\"connection_init\"}"),
+				new TextMessage(GREETING_QUERY));
+
+		StepVerifier.create(this.session.getOutput())
+				.consumeNextWith((message) -> assertMessageType(message, "connection_ack"))
+				.consumeNextWith((message) -> assertThat(decode(message))
+						.hasSize(3)
+						.containsEntry("id", SUBSCRIPTION_ID)
+						.containsEntry("type", "next")
+						.extractingByKey("payload", as(InstanceOfAssertFactories.map(String.class, Object.class)))
+						.extractingByKey("data", as(InstanceOfAssertFactories.map(String.class, Object.class)))
+						.containsEntry("greeting", "a"))
+				.consumeNextWith((message) -> assertThat(decode(message))
+						.hasSize(3)
+						.containsEntry("id", SUBSCRIPTION_ID)
+						.containsEntry("type", "error")
+						.hasEntrySatisfying("payload", payload -> assertThat(payload)
+								.asList()
+								.hasSize(1)
+								.allSatisfy(theError -> assertThat(theError)
+										.asInstanceOf(InstanceOfAssertFactories.map(String.class, Object.class))
+										.hasSize(3)
+										.hasEntrySatisfying("locations", loc -> assertThat(loc).asList().isEmpty())
+										.hasEntrySatisfying("message", msg -> assertThat(msg).asString().contains("null"))
+										.extractingByKey("extensions", as(InstanceOfAssertFactories.map(String.class, Object.class)))
+										.containsEntry("classification", "DataFetchingException"))))
+				.then(this.session::close)
+				.verifyComplete();
 	}
 
 	private void handle(GraphQlWebSocketHandler handler, TextMessage... textMessages) throws Exception {


### PR DESCRIPTION
Fixes spring-projects/spring-graphql#200

This is my first ever Spring contribution, please let me know if anything should be changed.

Is there a replacement for `Collections#singletonList` in Spring?

Documentation describing expected behaviour:
* https://github.com/enisdenjo/graphql-ws/blob/master/docs/interfaces/common.ErrorMessage.md

## Screenshots

In this example I modified https://github.com/spring-projects/spring-graphql/blob/4d99d2ab314cf59d92ed3aa6d42834c0176dfe06/samples/webflux-websocket/src/main/java/io/spring/sample/graphql/DataRepository.java#L52 to the following:
```java
return Flux.just("Hi", "Bonjour", "Hola", "Ciao", "Zdravo").map(s -> {
    if (s.equalsIgnoreCase("Zdravo")) {
        throw new RuntimeException("Test Exception");
    }
    return s + " " + name;
});
```

Before:
![afbeelding](https://user-images.githubusercontent.com/30464310/143684782-5a280f4e-9648-4f44-93c9-b49b810fa97c.png)

After:
![afbeelding](https://user-images.githubusercontent.com/30464310/143684921-5e608b7f-c6c1-44a0-a91c-f978b643e111.png)

Normal (without errors):
![afbeelding](https://user-images.githubusercontent.com/30464310/143684808-7c37ff74-3ea9-4d1f-9eea-492b0ca0a0e3.png)