### PR TITLE
Upgrade Log4j to 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ configure(moduleProjects) {
 				entry 'mongodb-driver-core'
 				entry 'bson'
 			}
-			dependencySet(group: 'org.apache.logging.log4j', version: '2.14.1') {
+			dependencySet(group: 'org.apache.logging.log4j', version: '2.16.0') {
 				entry 'log4j-api'
 				entry 'log4j-core'
 				entry 'log4j-jul'


### PR DESCRIPTION
The previous versions have the vulnerability CVE-2021-44228