### PR TITLE
Failure on null arguments on a method a reactive signature

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/InvocableHandlerMethodSupport.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/InvocableHandlerMethodSupport.java
@@ -96,7 +96,7 @@ public abstract class InvocableHandlerMethodSupport extends HandlerMethod {
 
 		List<Mono<Object>> monoList = Arrays.stream(args)
 				.map(arg -> {
-					Mono<Object> argMono = (arg instanceof Mono ? (Mono<Object>) arg : Mono.just(arg));
+					Mono<Object> argMono = (arg instanceof Mono ? (Mono<Object>) arg : Mono.justOrEmpty(arg));
 					return argMono.defaultIfEmpty(NO_VALUE);
 				})
 				.collect(Collectors.toList());


### PR DESCRIPTION
Previously when the argument contained a null value (for example for a nullified continuation when using a suspend fun), it would fail to convert the arguments, because of a `NullPointerException`.

By allowing the mono value be nullable it converts the arguments successfully.

I noticed this issue when I started using a `Principal` argument in one my query functions.