### PR TITLE
Use correct sub-protocol for the deprecated subscriptions-transport-ws library

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandler.java
@@ -71,7 +71,7 @@ public class GraphQlWebSocketHandler implements WebSocketHandler {
 	private static final Log logger = LogFactory.getLog(GraphQlWebSocketHandler.class);
 
 	private static final List<String> SUB_PROTOCOL_LIST =
-			Arrays.asList("graphql-transport-ws", "subscriptions-transport-ws");
+			Arrays.asList("graphql-transport-ws", "graphql-ws");
 
 	static final ResolvableType MAP_RESOLVABLE_TYPE =
 			ResolvableType.forType(new ParameterizedTypeReference<Map<String, Object>>() {});
@@ -127,7 +127,7 @@ public class GraphQlWebSocketHandler implements WebSocketHandler {
 	@Override
 	public Mono<Void> handle(WebSocketSession session) {
 		HandshakeInfo handshakeInfo = session.getHandshakeInfo();
-		if ("subscriptions-transport-ws".equalsIgnoreCase(handshakeInfo.getSubProtocol())) {
+		if ("graphql-ws".equalsIgnoreCase(handshakeInfo.getSubProtocol())) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("apollographql/subscriptions-transport-ws is not supported, nor maintained. "
 						+ "Please, use https://github.com/enisdenjo/graphql-ws.");

--- a/spring-graphql/src/main/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandler.java
@@ -74,7 +74,7 @@ public class GraphQlWebSocketHandler extends TextWebSocketHandler implements Sub
 	private static final Log logger = LogFactory.getLog(GraphQlWebSocketHandler.class);
 
 	private static final List<String> SUB_PROTOCOL_LIST =
-			Arrays.asList("graphql-transport-ws", "subscriptions-transport-ws");
+			Arrays.asList("graphql-transport-ws", "graphql-ws");
 
 
 	private final WebGraphQlHandler graphQlHandler;
@@ -110,7 +110,7 @@ public class GraphQlWebSocketHandler extends TextWebSocketHandler implements Sub
 
 	@Override
 	public void afterConnectionEstablished(WebSocketSession session) {
-		if ("subscriptions-transport-ws".equalsIgnoreCase(session.getAcceptedProtocol())) {
+		if ("graphql-ws".equalsIgnoreCase(session.getAcceptedProtocol())) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("apollographql/subscriptions-transport-ws is not supported, nor maintained. "
 						+ "Please, use https://github.com/enisdenjo/graphql-ws.");


### PR DESCRIPTION
 Subprotocol of subscriptions-transport-ws is `graphql-ws`.


|   | Protocol/Library | SubProtocol |  
|---|----------|-------------|
|   |     graphql-ws     |      graphql-transport-ws       | 
|   |       subscriptions-transport-ws   |        graphql-ws     | 


https://github.com/apollographql/subscriptions-transport-ws/blob/05a828f4ce9164df61cc0a08ab225556fc035801/src/protocol.ts#L1

https://github.com/apollographql/apollo-kotlin/blob/ac10257283e1196c3feb0d8f1a3b5d9476ad681a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/SubscriptionWsProtocol.kt#L83

https://github.com/apollographql/apollo-kotlin/blob/ac10257283e1196c3feb0d8f1a3b5d9476ad681a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/SubscriptionWsProtocol.kt#L83
