### PR TITLE
Support for GraphQL over WebSocket `Ping` and `Pong` message types

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/web/WebGraphQlHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/WebGraphQlHandler.java
@@ -60,23 +60,6 @@ public interface WebGraphQlHandler {
 		return Mono.empty();
 	}
 
-	/**
-	 * Handle the <a href="https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#ping">ping message</a>
-	 * for "heartbeat/keepalive" that many GraphQL clients send to keep the session alive.
-	 * @return returns a simple "pong" message
-	 */
-	default Mono<Void> handleWebSocketPing() {
-		return Mono.empty();
-	}
-
-	/**
-	 * Handle the <a href="https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#pong">ping message</a>
-	 * for "heartbeat/keepalive" that many GraphQL clients send to keep the session alive.
-	 * @return returns a simple "pong" message
-	 */
-	default Mono<Void> handleWebSocketPong() {
-		return Mono.empty();
-	}
 
 	/**
 	 * Provides access to a builder to create a {@link WebGraphQlHandler} instance.

--- a/spring-graphql/src/main/java/org/springframework/graphql/web/WebGraphQlHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/WebGraphQlHandler.java
@@ -70,6 +70,15 @@ public interface WebGraphQlHandler {
 	}
 
 	/**
+	 * Handle the <a href="https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#pong">ping message</a>
+	 * for "heartbeat/keepalive" that many GraphQL clients send to keep the session alive.
+	 * @return returns a simple "pong" message
+	 */
+	default Mono<Void> handleWebSocketPong() {
+		return Mono.empty();
+	}
+
+	/**
 	 * Provides access to a builder to create a {@link WebGraphQlHandler} instance.
 	 * @param graphQlService the {@link GraphQlService} to use for actual execution of the
 	 * request.

--- a/spring-graphql/src/main/java/org/springframework/graphql/web/WebGraphQlHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/WebGraphQlHandler.java
@@ -60,6 +60,14 @@ public interface WebGraphQlHandler {
 		return Mono.empty();
 	}
 
+	/**
+	 * Handle the <a href="https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#ping">ping message</a>
+	 * for "heartbeat/keepalive" that many GraphQL clients send to keep the session alive.
+	 * @return returns a simple "pong" message
+	 */
+	default Mono<Void> handleWebSocketPing() {
+		return Mono.empty();
+	}
 
 	/**
 	 * Provides access to a builder to create a {@link WebGraphQlHandler} instance.

--- a/spring-graphql/src/main/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandler.java
@@ -178,6 +178,8 @@ public class GraphQlWebSocketHandler implements WebSocketHandler {
 				return this.graphQlHandler.handleWebSocketCompletion().thenMany(Flux.empty());
 			case PING:
 				return this.graphQlHandler.handleWebSocketPing().thenMany(Flux.just(encode(session, null, MessageType.PONG, null)));
+			case PONG:
+				return this.graphQlHandler.handleWebSocketPong().thenMany(Flux.empty());
 			case CONNECTION_INIT:
 				if (!connectionInitProcessed.compareAndSet(false, true)) {
 					return GraphQlStatus.close(session, GraphQlStatus.TOO_MANY_INIT_REQUESTS_STATUS);

--- a/spring-graphql/src/main/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandler.java
@@ -176,6 +176,8 @@ public class GraphQlWebSocketHandler implements WebSocketHandler {
 					}
 				}
 				return this.graphQlHandler.handleWebSocketCompletion().thenMany(Flux.empty());
+			case PING:
+				return this.graphQlHandler.handleWebSocketPing().thenMany(Flux.just(encode(session, null, MessageType.PONG, null)));
 			case CONNECTION_INIT:
 				if (!connectionInitProcessed.compareAndSet(false, true)) {
 					return GraphQlStatus.close(session, GraphQlStatus.TOO_MANY_INIT_REQUESTS_STATUS);
@@ -274,6 +276,8 @@ public class GraphQlWebSocketHandler implements WebSocketHandler {
 		CONNECTION_INIT("connection_init"),
 		CONNECTION_ACK("connection_ack"),
 		SUBSCRIBE("subscribe"),
+		PING("ping"),
+		PONG("pong"),
 		NEXT("next"),
 		ERROR("error"),
 		COMPLETE("complete");

--- a/spring-graphql/src/main/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/webflux/GraphQlWebSocketHandler.java
@@ -177,9 +177,9 @@ public class GraphQlWebSocketHandler implements WebSocketHandler {
 				}
 				return this.graphQlHandler.handleWebSocketCompletion().thenMany(Flux.empty());
 			case PING:
-				return this.graphQlHandler.handleWebSocketPing().thenMany(Flux.just(encode(session, null, MessageType.PONG, null)));
+				return Mono.empty().thenMany(Flux.just(encode(session, null, MessageType.PONG, null)));
 			case PONG:
-				return this.graphQlHandler.handleWebSocketPong().thenMany(Flux.empty());
+				return Mono.empty().thenMany(Flux.empty());
 			case CONNECTION_INIT:
 				if (!connectionInitProcessed.compareAndSet(false, true)) {
 					return GraphQlStatus.close(session, GraphQlStatus.TOO_MANY_INIT_REQUESTS_STATUS);

--- a/spring-graphql/src/main/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandler.java
@@ -173,6 +173,9 @@ public class GraphQlWebSocketHandler extends TextWebSocketHandler implements Sub
 			}
 			this.graphQlHandler.handleWebSocketCompletion().block(Duration.ofSeconds(10));
 			return;
+		case PING:
+			this.graphQlHandler.handleWebSocketPing().block(Duration.ofSeconds(10));
+			return;
 		case CONNECTION_INIT:
 			if (sessionState.setConnectionInitProcessed()) {
 				GraphQlStatus.closeSession(session, GraphQlStatus.TOO_MANY_INIT_REQUESTS_STATUS);
@@ -313,6 +316,8 @@ public class GraphQlWebSocketHandler extends TextWebSocketHandler implements Sub
 		CONNECTION_INIT("connection_init"),
 		CONNECTION_ACK("connection_ack"),
 		SUBSCRIBE("subscribe"),
+		PING("ping"),
+		PONG("pong"),
 		NEXT("next"),
 		ERROR("error"),
 		COMPLETE("complete");

--- a/spring-graphql/src/main/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandler.java
@@ -176,6 +176,9 @@ public class GraphQlWebSocketHandler extends TextWebSocketHandler implements Sub
 		case PING:
 			this.graphQlHandler.handleWebSocketPing().block(Duration.ofSeconds(10));
 			return;
+		case PONG:
+			this.graphQlHandler.handleWebSocketPong().block(Duration.ofSeconds(10));
+			return;
 		case CONNECTION_INIT:
 			if (sessionState.setConnectionInitProcessed()) {
 				GraphQlStatus.closeSession(session, GraphQlStatus.TOO_MANY_INIT_REQUESTS_STATUS);

--- a/spring-graphql/src/main/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/web/webmvc/GraphQlWebSocketHandler.java
@@ -174,10 +174,8 @@ public class GraphQlWebSocketHandler extends TextWebSocketHandler implements Sub
 			this.graphQlHandler.handleWebSocketCompletion().block(Duration.ofSeconds(10));
 			return;
 		case PING:
-			this.graphQlHandler.handleWebSocketPing().block(Duration.ofSeconds(10));
-			return;
 		case PONG:
-			this.graphQlHandler.handleWebSocketPong().block(Duration.ofSeconds(10));
+			Mono.empty().block(Duration.ofSeconds(10));
 			return;
 		case CONNECTION_INIT:
 			if (sessionState.setConnectionInitProcessed()) {


### PR DESCRIPTION
This PR implements the missing `PING` and `PONG` GraphQL WS messages for the client-side "heartbeat / keep alive" function.

Now the system does not close the connection when it receives a `PING` message, but sends a corresponding (`PONG`) message back, as specified in the [graphql-ws protocol](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#ping).