### PR TITLE
Support custom HandlerMethodArgumentResolver for @SchemaMapping

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/HandlerMethodArgumentResolverComposite.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/HandlerMethodArgumentResolverComposite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.lang.Nullable;
  * Previously resolved method parameters are cached for faster lookups.
  *
  * @author Rossen Stoyanchev
+ * @author Genkui Du
  * @since 1.0.0
  */
 public class HandlerMethodArgumentResolverComposite implements HandlerMethodArgumentResolver {
@@ -47,6 +48,18 @@ public class HandlerMethodArgumentResolverComposite implements HandlerMethodArgu
 	 */
 	public void addResolver(HandlerMethodArgumentResolver resolver) {
 		this.argumentResolvers.add(resolver);
+	}
+
+	/**
+	 * Add the given {@link HandlerMethodArgumentResolver HandlerMethodArgumentResolvers}.
+	 */
+	public HandlerMethodArgumentResolverComposite addResolvers(
+			@Nullable List<? extends HandlerMethodArgumentResolver> resolvers) {
+
+		if (resolvers != null) {
+			this.argumentResolvers.addAll(resolvers);
+		}
+		return this;
 	}
 
 	/**

--- a/spring-graphql/src/testFixtures/java/org/springframework/graphql/GraphQlSetup.java
+++ b/spring-graphql/src/testFixtures/java/org/springframework/graphql/GraphQlSetup.java
@@ -28,6 +28,7 @@ import graphql.schema.TypeResolver;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
+import org.springframework.graphql.data.method.HandlerMethodArgumentResolver;
 import org.springframework.graphql.data.method.annotation.support.AnnotatedControllerConfigurer;
 import org.springframework.graphql.execution.DataFetcherExceptionResolver;
 import org.springframework.graphql.execution.DataLoaderRegistrar;
@@ -85,8 +86,13 @@ public class GraphQlSetup implements GraphQlServiceSetup {
 	}
 
 	public GraphQlSetup runtimeWiringForAnnotatedControllers(ApplicationContext context) {
+		return this.runtimeWiringForAnnotatedControllers(context, new ArrayList<>());
+	}
+
+	public GraphQlSetup runtimeWiringForAnnotatedControllers(ApplicationContext context, List<HandlerMethodArgumentResolver> argumentResolverList) {
 		AnnotatedControllerConfigurer configurer = new AnnotatedControllerConfigurer();
 		configurer.setApplicationContext(context);
+		configurer.setCustomArgumentResolvers(argumentResolverList);
 		configurer.afterPropertiesSet();
 		return runtimeWiring(configurer);
 	}


### PR DESCRIPTION
This PR supports custom HandlerMethodArgumentResolver. #259

The implementation refers to [spring-framework: mvc/method/annotation/RequestMappingHandlerAdapter.java](https://github.com/spring-projects/spring-framework/blob/main/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java)