### PR TITLE
Support for BatchHandlerMethodArgumentResolver

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/BatchHandlerMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/BatchHandlerMethodArgumentResolver.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.graphql.data.method;
+
+import graphql.schema.DataFetchingEnvironment;
+import org.dataloader.BatchLoaderEnvironment;
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.Nullable;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Strategy interface for resolving method parameters into argument values in
+ * the context of a given {@link BatchLoaderEnvironment} and parent/source list.
+ *
+ * <p>Most implementations will be synchronous, simply resolving values from the
+ * {@code BatchLoaderEnvironment} and parent/source list. However, a resolver may
+ * also return a {@link reactor.core.publisher.Mono} if it needs to be asynchronous.
+ *
+ * @author Genkui Du
+ * @since 1.0.0
+ */
+public interface BatchHandlerMethodArgumentResolver {
+
+	/**
+	 * Whether this resolver supports the given {@link MethodParameter}.
+	 *
+	 * @param parameter the method parameter
+	 */
+	boolean supportsParameter(MethodParameter parameter);
+
+	/**
+	 * Resolve a method parameter into an argument value.
+	 *
+	 * @param parameter   the method parameter to resolve. This parameter must
+	 *                    have previously checked via {@link #supportsParameter}.
+	 * @param keys        the list of keys to load
+	 * @param keyContexts keys and their context objects map
+	 * @param environment the environment to use to resolve the value
+	 * @param <K>         the type of parent/source type.
+	 *
+	 * @return the resolved value, which may be {@code null} if not resolved;
+	 * the value may also be a {@link reactor.core.publisher.Mono} if it
+	 * requires asynchronous resolution.
+	 *
+	 * @throws Exception in case of errors with the preparation of argument values
+	 */
+	@Nullable
+	<K> Object resolveArgument(MethodParameter parameter,
+							   Collection<K> keys,
+							   Map<K, ? extends DataFetchingEnvironment> keyContexts,
+							   BatchLoaderEnvironment environment) throws Exception;
+
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/BatchHandlerMethodArgumentResolverComposite.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/BatchHandlerMethodArgumentResolverComposite.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.graphql.data.method;
+
+import graphql.schema.DataFetchingEnvironment;
+import org.dataloader.BatchLoaderEnvironment;
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Resolves method parameters by delegating to a list of registered
+ * {@link BatchHandlerMethodArgumentResolver BatchHandlerMethodArgumentResolvers}.
+ * Previously resolved method parameters are cached for faster lookups.
+ *
+ * @author Genkui Du
+ * @since 1.0.0
+ */
+public class BatchHandlerMethodArgumentResolverComposite implements BatchHandlerMethodArgumentResolver {
+
+    private final List<BatchHandlerMethodArgumentResolver> argumentResolvers = new ArrayList<>();
+
+    private final Map<MethodParameter, BatchHandlerMethodArgumentResolver> argumentResolverCache =
+            new ConcurrentHashMap<>(256);
+
+
+    /**
+     * Return a read-only list with the contained resolvers, or an empty list.
+     */
+    public List<BatchHandlerMethodArgumentResolver> getArgumentResolvers() {
+        return Collections.unmodifiableList(argumentResolvers);
+    }
+
+    /**
+     * Add the given {@link BatchHandlerMethodArgumentResolver BatchHandlerMethodArgumentResolvers}.
+     */
+    public BatchHandlerMethodArgumentResolverComposite addResolvers(
+            @Nullable List<? extends BatchHandlerMethodArgumentResolver> resolvers) {
+
+        if (resolvers != null) {
+            this.argumentResolvers.addAll(resolvers);
+        }
+        return this;
+    }
+
+    /**
+     * Clear the list of configured resolvers and the resolver cache.
+     */
+    public void clear() {
+        this.argumentResolvers.clear();
+        this.argumentResolverCache.clear();
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return this.getArgumentResolver(parameter) != null;
+    }
+
+    @Override
+    public <K> Object resolveArgument(MethodParameter parameter,
+                                      Collection<K> keys,
+                                      Map<K, ? extends DataFetchingEnvironment> keyContexts,
+                                      BatchLoaderEnvironment environment) throws Exception {
+
+        BatchHandlerMethodArgumentResolver argumentResolver = getArgumentResolver(parameter);
+        if (argumentResolver == null) {
+            throw new IllegalArgumentException("Unsupported parameter type [" +
+                    parameter.getParameterType().getName() + "]. supportsParameter should be called first.");
+        }
+        return argumentResolver.resolveArgument(parameter, keys, keyContexts, environment);
+
+    }
+
+    /**
+     * Find a registered {@link BatchHandlerMethodArgumentResolver} that supports
+     * the given method parameter.
+     */
+    @Nullable
+    private BatchHandlerMethodArgumentResolver getArgumentResolver(MethodParameter parameter) {
+        BatchHandlerMethodArgumentResolver result = argumentResolverCache.get(parameter);
+        if (result == null) {
+            for (BatchHandlerMethodArgumentResolver argumentResolver : this.argumentResolvers) {
+                if (argumentResolver.supportsParameter(parameter)) {
+                    result = argumentResolver;
+                    this.argumentResolverCache.put(parameter, argumentResolver);
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/HandlerMethodArgumentResolverComposite.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/HandlerMethodArgumentResolverComposite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,18 @@ public class HandlerMethodArgumentResolverComposite implements HandlerMethodArgu
 	 */
 	public void addResolver(HandlerMethodArgumentResolver resolver) {
 		this.argumentResolvers.add(resolver);
+	}
+
+	/**
+	 * Add the given {@link HandlerMethodArgumentResolver HandlerMethodArgumentResolvers}.
+	 */
+	public HandlerMethodArgumentResolverComposite addResolvers(
+			@Nullable List<? extends HandlerMethodArgumentResolver> resolvers) {
+
+		if (resolvers != null) {
+			this.argumentResolvers.addAll(resolvers);
+		}
+		return this;
 	}
 
 	/**

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/AnnotatedControllerConfigurer.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/AnnotatedControllerConfigurer.java
@@ -18,11 +18,13 @@ package org.springframework.graphql.data.method.annotation.support;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -38,6 +40,14 @@ import org.apache.commons.logging.LogFactory;
 import org.dataloader.DataLoader;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.expression.BeanResolver;
+import org.springframework.graphql.data.method.BatchHandlerMethodArgumentResolver;
+import org.springframework.graphql.data.method.BatchHandlerMethodArgumentResolverComposite;
+import org.springframework.graphql.data.method.annotation.support.batch.BatchLoaderEnvironmentBatchMethodArgumentResolver;
+import org.springframework.graphql.data.method.annotation.support.batch.ContextValueBatchMethodArgumentResolver;
+import org.springframework.graphql.data.method.annotation.support.batch.ContinuationBatchMethodArgumentResolver;
+import org.springframework.graphql.data.method.annotation.support.batch.GraphQLContextBatchMethodArgumentResolver;
+import org.springframework.graphql.data.method.annotation.support.batch.PrincipalBatchMethodArgumentResolver;
+import org.springframework.graphql.data.method.annotation.support.batch.SourceBatchMethodArgumentResolver;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -74,6 +84,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Rossen Stoyanchev
  * @author Brian Clozel
+ * @author Genkui Du
  * @since 1.0.0
  */
 public class AnnotatedControllerConfigurer
@@ -110,6 +121,9 @@ public class AnnotatedControllerConfigurer
 
 	@Nullable
 	private HandlerMethodArgumentResolverComposite argumentResolvers;
+
+	@Nullable
+	private BatchHandlerMethodArgumentResolverComposite batchMethodArgumentResolvers;
 
 	@Nullable
 	private HandlerMethodInputValidator validator;
@@ -151,37 +165,64 @@ public class AnnotatedControllerConfigurer
 
 	@Override
 	public void afterPropertiesSet() {
-		this.argumentResolvers = new HandlerMethodArgumentResolverComposite();
 
-		// Annotation based
-		if (springDataPresent) {
-			// Must be ahead of ArgumentMethodArgumentResolver
-			this.argumentResolvers.addResolver(new ProjectedPayloadMethodArgumentResolver());
-		}
-		this.argumentResolvers.addResolver(new ArgumentMapMethodArgumentResolver());
-		GraphQlArgumentInitializer initializer = new GraphQlArgumentInitializer(this.conversionService);
-		this.argumentResolvers.addResolver(new ArgumentMethodArgumentResolver(initializer));
-		this.argumentResolvers.addResolver(new ArgumentsMethodArgumentResolver(initializer));
-		this.argumentResolvers.addResolver(new ContextValueMethodArgumentResolver());
+		List<HandlerMethodArgumentResolver> resolvers = getDefaultArgumentResolvers();
+		this.argumentResolvers = new HandlerMethodArgumentResolverComposite().addResolvers(resolvers);
 
-		// Type based
-		this.argumentResolvers.addResolver(new DataFetchingEnvironmentMethodArgumentResolver());
-		this.argumentResolvers.addResolver(new DataLoaderMethodArgumentResolver());
-		if (springSecurityPresent) {
-			this.argumentResolvers.addResolver(new PrincipalMethodArgumentResolver());
-			BeanResolver beanResolver = new BeanFactoryResolver(obtainApplicationContext());
-			this.argumentResolvers.addResolver(new AuthenticationPrincipalArgumentResolver(beanResolver));
-		}
-		if (KotlinDetector.isKotlinPresent()) {
-			this.argumentResolvers.addResolver(new ContinuationHandlerMethodArgumentResolver());
-		}
-
-		// This works as a fallback, after other resolvers
-		this.argumentResolvers.addResolver(new SourceMethodArgumentResolver());
+		List<BatchHandlerMethodArgumentResolver> batchMethodResolvers = getBatchMethodDefaultArgumentResolvers();
+		batchMethodArgumentResolvers = new BatchHandlerMethodArgumentResolverComposite().addResolvers(batchMethodResolvers);
 
 		if (beanValidationPresent) {
 			this.validator = HandlerMethodInputValidatorFactory.create(obtainApplicationContext());
 		}
+	}
+
+	private List<HandlerMethodArgumentResolver> getDefaultArgumentResolvers() {
+		List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>();
+
+		// Annotation based
+		if (springDataPresent) {
+			// Must be ahead of ArgumentMethodArgumentResolver
+			resolvers.add(new ProjectedPayloadMethodArgumentResolver());
+		}
+		resolvers.add(new ArgumentMapMethodArgumentResolver());
+		GraphQlArgumentInitializer initializer = new GraphQlArgumentInitializer(this.conversionService);
+		resolvers.add(new ArgumentMethodArgumentResolver(initializer));
+		resolvers.add(new ArgumentsMethodArgumentResolver(initializer));
+		resolvers.add(new ContextValueMethodArgumentResolver());
+
+		// Type based
+		resolvers.add(new DataFetchingEnvironmentMethodArgumentResolver());
+		resolvers.add(new DataLoaderMethodArgumentResolver());
+		if (springSecurityPresent) {
+			resolvers.add(new PrincipalMethodArgumentResolver());
+			BeanResolver beanResolver = new BeanFactoryResolver(obtainApplicationContext());
+			resolvers.add(new AuthenticationPrincipalArgumentResolver(beanResolver));
+		}
+		if (KotlinDetector.isKotlinPresent()) {
+			resolvers.add(new ContinuationHandlerMethodArgumentResolver());
+		}
+
+		// This works as a fallback, after other resolvers
+		resolvers.add(new SourceMethodArgumentResolver());
+
+		return resolvers;
+	}
+
+	private List<BatchHandlerMethodArgumentResolver> getBatchMethodDefaultArgumentResolvers() {
+		List<BatchHandlerMethodArgumentResolver> resolvers = new ArrayList<>();
+
+		resolvers.add(new SourceBatchMethodArgumentResolver());
+		resolvers.add(new ContextValueBatchMethodArgumentResolver());
+		resolvers.add(new GraphQLContextBatchMethodArgumentResolver());
+		resolvers.add(new BatchLoaderEnvironmentBatchMethodArgumentResolver());
+		if (KotlinDetector.isKotlinPresent()) {
+			resolvers.add(new ContinuationBatchMethodArgumentResolver());
+		}
+		if (springSecurityPresent) {
+			resolvers.add(new PrincipalBatchMethodArgumentResolver());
+		}
+		return resolvers;
 	}
 
 	@Override
@@ -355,7 +396,7 @@ public class AnnotatedControllerConfigurer
 		BatchLoaderRegistry registry = obtainApplicationContext().getBean(BatchLoaderRegistry.class);
 
 		HandlerMethod handlerMethod = info.getHandlerMethod();
-		BatchLoaderHandlerMethod invocable = new BatchLoaderHandlerMethod(handlerMethod);
+		BatchLoaderHandlerMethod invocable = new BatchLoaderHandlerMethod(handlerMethod, this.batchMethodArgumentResolvers);
 
 		Class<?> clazz = handlerMethod.getReturnType().getParameterType();
 		if (clazz.equals(Flux.class) || Collection.class.isAssignableFrom(clazz)) {
@@ -465,7 +506,7 @@ public class AnnotatedControllerConfigurer
 			if (dataLoader == null) {
 				throw new IllegalStateException("No DataLoader for key '" + this.dataLoaderKey + "'");
 			}
-			return dataLoader.load(env.getSource());
+			return dataLoader.load(env.getSource(), env);
 		}
 	}
 

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/BatchLoaderHandlerMethod.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/BatchLoaderHandlerMethod.java
@@ -47,12 +47,39 @@ public class BatchLoaderHandlerMethod extends InvocableHandlerMethodSupport {
 
 	private final BatchHandlerMethodArgumentResolverComposite resolvers;
 
-	public BatchLoaderHandlerMethod(HandlerMethod handlerMethod, BatchHandlerMethodArgumentResolverComposite resolvers) {
+	@Nullable
+	private final HandlerMethodInputValidator validator;
+
+	/**
+	 * Constructor with a parent handler method.
+	 * @param handlerMethod the handler method
+	 * @param resolvers the argument resolvers
+	 * @param validator the input validator
+	 */
+	public BatchLoaderHandlerMethod(HandlerMethod handlerMethod,
+									BatchHandlerMethodArgumentResolverComposite resolvers,
+									@Nullable HandlerMethodInputValidator validator) {
 		super(handlerMethod);
 		Assert.isTrue(!resolvers.getArgumentResolvers().isEmpty(), "No argument resolvers");
 		this.resolvers = resolvers;
+		this.validator = validator;
 	}
 
+
+	/**
+	 * Return the configured argument resolvers.
+	 */
+	public BatchHandlerMethodArgumentResolverComposite getResolvers() {
+		return resolvers;
+	}
+
+	/**
+	 * Return the configured input validator.
+	 */
+	@Nullable
+	public HandlerMethodInputValidator getValidator() {
+		return this.validator;
+	}
 
 	/**
 	 * Invoke the underlying batch loader method with a collection of keys to
@@ -69,6 +96,9 @@ public class BatchLoaderHandlerMethod extends InvocableHandlerMethodSupport {
 		Object[] args;
 		try {
 			args = getMethodArgumentValues(keys, environment);
+			if (this.validator != null) {
+				this.validator.validate(this, args);
+			}
 		}
 		catch (Throwable ex) {
 			return Mono.error(ex);
@@ -96,6 +126,9 @@ public class BatchLoaderHandlerMethod extends InvocableHandlerMethodSupport {
 		Object[] args;
 		try {
 			args = getMethodArgumentValues(keys, environment);
+			if (this.validator != null) {
+				this.validator.validate(this, args);
+			}
 		}
 		catch (Throwable ex) {
 			return Flux.error(ex);

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ContextValueMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ContextValueMethodArgumentResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class ContextValueMethodArgumentResolver implements HandlerMethodArgument
 	}
 
 	@Nullable
-	static Object resolveContextValue(
+	public static Object resolveContextValue(
 			MethodParameter parameter, @Nullable Object localContext, GraphQLContext graphQlContext) {
 
 		ContextValue annotation = parameter.getParameterAnnotation(ContextValue.class);

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/PrincipalMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/PrincipalMethodArgumentResolver.java
@@ -53,7 +53,7 @@ public class PrincipalMethodArgumentResolver implements HandlerMethodArgumentRes
 		return doResolve();
 	}
 
-	static Object doResolve() {
+	public static Object doResolve() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		return (authentication != null ? authentication :
 				ReactiveSecurityContextHolder.getContext().map(SecurityContext::getAuthentication));

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/BatchLoaderEnvironmentBatchMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/BatchLoaderEnvironmentBatchMethodArgumentResolver.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.graphql.data.method.annotation.support.batch;
+
+
+import graphql.schema.DataFetchingEnvironment;
+import org.dataloader.BatchLoaderEnvironment;
+import org.springframework.core.MethodParameter;
+import org.springframework.graphql.data.method.BatchHandlerMethodArgumentResolver;
+
+import java.util.Collection;
+import java.util.Map;
+
+
+/**
+ * Resolves {@link BatchLoaderEnvironment} method arguments.
+ *
+ * <p>For direct access to the underlying {@link BatchLoaderEnvironment}.
+ *
+ * @author Genkui Du
+ * @since 1.0.0
+ */
+public class BatchLoaderEnvironmentBatchMethodArgumentResolver implements BatchHandlerMethodArgumentResolver {
+
+    static BatchLoaderEnvironment DUMMY_ENVIRONMENT = BatchLoaderEnvironment.newBatchLoaderEnvironment().build();
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        Class<?> parameterType = parameter.getParameterType();
+        return parameterType.isInstance(DUMMY_ENVIRONMENT);
+    }
+
+    @Override
+    public <K> Object resolveArgument(MethodParameter parameter,
+                                      Collection<K> keys,
+                                      Map<K, ? extends DataFetchingEnvironment> keyContexts,
+                                      BatchLoaderEnvironment environment) throws Exception {
+        return environment;
+    }
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/ContextValueBatchMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/ContextValueBatchMethodArgumentResolver.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.graphql.data.method.annotation.support.batch;
+
+
+import graphql.schema.DataFetchingEnvironment;
+import org.dataloader.BatchLoaderEnvironment;
+import org.springframework.core.MethodParameter;
+import org.springframework.graphql.data.method.BatchHandlerMethodArgumentResolver;
+import org.springframework.graphql.data.method.annotation.ContextValue;
+import org.springframework.graphql.data.method.annotation.support.ContextValueMethodArgumentResolver;
+
+import java.util.Collection;
+import java.util.Map;
+
+
+/**
+ * Resolver for {@link ContextValue @ContextValue} annotated method parameters.
+ *
+ * <p>For access to a value from the GraphQLContext of BatchLoaderEnvironment,
+ * which is the same context as the one from the DataFetchingEnvironment.
+ *
+ * @author Genkui Du
+ * @since 1.0.0
+ */
+public class ContextValueBatchMethodArgumentResolver implements BatchHandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(ContextValue.class);
+    }
+
+    @Override
+    public <K> Object resolveArgument(MethodParameter parameter,
+                                      Collection<K> keys,
+                                      Map<K, ? extends DataFetchingEnvironment> keyContexts,
+                                      BatchLoaderEnvironment environment) throws Exception {
+        if(keyContexts.isEmpty()){
+            return null;
+        }
+
+        return ContextValueMethodArgumentResolver.resolveContextValue(parameter, null, environment.getContext());
+    }
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/ContinuationBatchMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/ContinuationBatchMethodArgumentResolver.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.graphql.data.method.annotation.support.batch;
+
+import graphql.schema.DataFetchingEnvironment;
+import org.dataloader.BatchLoaderEnvironment;
+import org.springframework.core.MethodParameter;
+import org.springframework.graphql.data.method.BatchHandlerMethodArgumentResolver;
+
+import java.util.Collection;
+import java.util.Map;
+
+
+/**
+ * No-op resolver for method arguments of type {@link kotlin.coroutines.Continuation}.
+ *
+ * @author Genkui Du
+ * @since 1.0.0
+ */
+public class ContinuationBatchMethodArgumentResolver implements BatchHandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        Class<?> parameterType = parameter.getParameterType();
+        return "kotlin.coroutines.Continuation".equals(parameterType.getName());
+    }
+
+    @Override
+    public <K> Object resolveArgument(MethodParameter parameter,
+                                      Collection<K> keys,
+                                      Map<K, ? extends DataFetchingEnvironment> keyContexts,
+                                      BatchLoaderEnvironment environment) throws Exception {
+        return null;
+    }
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/GraphQLContextBatchMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/GraphQLContextBatchMethodArgumentResolver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.graphql.data.method.annotation.support.batch;
+
+import graphql.GraphQLContext;
+import graphql.schema.DataFetchingEnvironment;
+import org.dataloader.BatchLoaderEnvironment;
+import org.springframework.core.MethodParameter;
+import org.springframework.graphql.data.method.BatchHandlerMethodArgumentResolver;
+
+import java.util.Collection;
+import java.util.Map;
+
+
+/**
+ * Resolver for access to the context from the BatchLoaderEnvironment,
+ * which is the same context as the one from the DataFetchingEnvironment.
+ *
+ * @author Genkui Du
+ * @since 1.0.0
+ */
+public class GraphQLContextBatchMethodArgumentResolver implements BatchHandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        Class<?> parameterType = parameter.getParameterType();
+        return parameterType.equals(GraphQLContext.class);
+    }
+
+    @Override
+    public <K> Object resolveArgument(MethodParameter parameter,
+                                      Collection<K> keys,
+                                      Map<K, ? extends DataFetchingEnvironment> keyContexts,
+                                      BatchLoaderEnvironment environment) throws Exception {
+        return environment.getContext();
+    }
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/PrincipalBatchMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/PrincipalBatchMethodArgumentResolver.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.graphql.data.method.annotation.support.batch;
+
+import graphql.schema.DataFetchingEnvironment;
+import org.dataloader.BatchLoaderEnvironment;
+import org.springframework.core.MethodParameter;
+import org.springframework.graphql.data.method.BatchHandlerMethodArgumentResolver;
+import org.springframework.graphql.data.method.annotation.support.AnnotatedControllerConfigurer;
+import org.springframework.graphql.data.method.annotation.support.PrincipalMethodArgumentResolver;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ClassUtils;
+
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Map;
+
+
+/**
+ * Resolver to obtain {@link Principal} from Spring Security context via
+ * {@link SecurityContext#getAuthentication()}.
+ *
+ * <p>The resolver checks both ThreadLocal context via {@link SecurityContextHolder}
+ * for Spring MVC applications, and {@link ReactiveSecurityContextHolder} for
+ * Spring WebFlux applications. It returns .
+ *
+ * @author Genkui Du
+ * @since 1.0.0
+ */
+public class PrincipalBatchMethodArgumentResolver implements BatchHandlerMethodArgumentResolver {
+
+    private final static boolean springSecurityPresent = ClassUtils.isPresent(
+            "org.springframework.security.core.context.SecurityContext",
+            AnnotatedControllerConfigurer.class.getClassLoader());
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return springSecurityPresent && Principal.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public <K> Object resolveArgument(MethodParameter parameter,
+                                      Collection<K> keys,
+                                      Map<K, ? extends DataFetchingEnvironment> keyContexts,
+                                      BatchLoaderEnvironment environment) throws Exception {
+        return PrincipalMethodArgumentResolver.doResolve();
+    }
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/SourceBatchMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/SourceBatchMethodArgumentResolver.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.graphql.data.method.annotation.support.batch;
+
+import graphql.schema.DataFetchingEnvironment;
+import org.dataloader.BatchLoaderEnvironment;
+import org.springframework.core.CollectionFactory;
+import org.springframework.core.MethodParameter;
+import org.springframework.graphql.data.method.BatchHandlerMethodArgumentResolver;
+
+import java.util.Collection;
+import java.util.Map;
+
+
+/**
+ * Resolver for access source/parent objects.
+ *
+ * @author GenKui Du
+ * @since 1.0.0
+ */
+public class SourceBatchMethodArgumentResolver implements BatchHandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        Class<?> parameterType = parameter.getParameterType();
+        return Collection.class.isAssignableFrom(parameterType);
+    }
+
+    @Override
+    public <K> Object resolveArgument(MethodParameter parameter,
+                                      Collection<K> keys,
+                                      Map<K, ? extends DataFetchingEnvironment> keyContexts,
+                                      BatchLoaderEnvironment environment) throws Exception {
+        Class<?> parameterType = parameter.getParameterType();
+        if (parameterType.isInstance(keys)) {
+            return keys;
+        }
+
+        Class<?> elementType = parameter.nested().getNestedParameterType();
+        Collection<K> collection = CollectionFactory.createCollection(parameterType, elementType, keys.size());
+        collection.addAll(keys);
+        return collection;
+    }
+
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/package-info.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/batch/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * Resolvers for method parameters of annotated batch handler methods.
+ */
+package org.springframework.graphql.data.method.annotation.support.batch;


### PR DESCRIPTION
## The purpose of this PR

Replace hard code in `BatchLoaderHandlerMethod ` with `BatchHandlerMethodArgumentResolver`, and support custom `BatchHandlerMethodArgumentResolver`.

### 1、The reason spring-graphql should support `BatchHandlerMethodArgumentResolver`
In #232 , I suggested that `@BatchMapping` should support `@Argument`, because user will define arguments on field, no matter whether the field is fetched by DataLoader way or 'n+1' way. 

Furthermore, user will always want to get information about field, such as field definition or directives.

Hence, I think `BatchLoaderHandlerMethod` should support argumentResolveStrategies  which resolving argument values  into various  method parameters. 

### 2、The way spring-graphql support `BatchHandlerMethodArgumentResolver`
`BatchMappingDataFetcher` could pass DataFetchingEnvironment to DataLoader by invoking `dataLoader.load(env.getSource(), env)`(the following code), and `BatchLoaderHandlerMethod` and argument resolve strategies will get all the information about the fetched field.
```java
	static class BatchMappingDataFetcher implements DataFetcher<Object> {
                ......
		@Override
		public Object get(DataFetchingEnvironment env) {
			DataLoader<?, ?> dataLoader = env.getDataLoaderRegistry().getDataLoader(this.dataLoaderKey);
			if (dataLoader == null) {
				throw new IllegalStateException("No DataLoader for key '" + this.dataLoaderKey + "'");
			}
                         // pass DataFetchingEnvironment to DataLoader and other component
			return dataLoader.load(env.getSource(), env);
		}
	}
```

## Brief change log


TODO: for validation and doc.