### PR TITLE
Fix implementation of `containsExactly`

### DIFF
--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
@@ -589,7 +589,7 @@ final class DefaultGraphQlTester implements GraphQlTester {
 				List<E> expected = Arrays.asList(elements);
 				AssertionErrors.assertTrue(
 						"List at path '" + getPath() + "' should have contained exactly " + expected,
-						getEntity().containsAll(expected));
+						getEntity().equals(expected));
 			});
 			return this;
 		}


### PR DESCRIPTION
The implementation was the same for `contains` and `containsExactly`, but `containsExactly` should fail when the number items doesn't match the size of the expected items list.