### PR TITLE
Update minimum requirement to GraphQL Java 18.0 

### DIFF
--- a/spring-graphql-docs/src/docs/asciidoc/index.adoc
+++ b/spring-graphql-docs/src/docs/asciidoc/index.adoc
@@ -30,7 +30,7 @@ Spring for GraphQL requires the following as a baseline:
 
 * JDK8
 * Spring Framework 5.3
-* GraphQL Java 17
+* GraphQL Java 18
 * Spring Data 2021.1.0 or later for QueryDSL or Query by Example
 
 


### PR DESCRIPTION
GraphQL Java updated to. version 18.0 as part of commit.
https://github.com/spring-projects/spring-graphql/commit/4d115c01cc71a683169d5551e8ebda9374cd5e26