### PR TITLE
Improve readability of assertion messages

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/support/DefaultExecutionGraphQlResponse.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/support/DefaultExecutionGraphQlResponse.java
@@ -152,6 +152,10 @@ public class DefaultExecutionGraphQlResponse extends AbstractGraphQlResponse imp
 			return (this.delegate.getExtensions() != null ? this.delegate.getExtensions() : Collections.emptyMap());
 		}
 
+		@Override
+		public String toString() {
+			return delegate.toString();
+		}
 	}
 
 

--- a/spring-graphql/src/test/java/org/springframework/graphql/client/GraphQlClientTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/client/GraphQlClientTests.java
@@ -205,7 +205,8 @@ public class GraphQlClientTests extends GraphQlClientTestSupport {
 		assertThat(nameField.getError().getParsedPath()).containsExactly("me", "name");
 		assertThatThrownBy(() -> nameField.toEntity(String.class))
 				.as("Decoding field null with direct field error should be rejected")
-				.isInstanceOf(FieldAccessException.class);
+				.isInstanceOf(FieldAccessException.class)
+				.hasMessageContaining("Test error");
 
 		ClientResponseField nonExistingField = response.field("me.name.other");
 		assertThat(nonExistingField.hasValue()).isFalse();


### PR DESCRIPTION
If there is an request processing error, e.g. syntax error:

```
User u = gql.document("{user(login: \"john\"){{ login status} }")
	.execute()
	.path("user")
	.entity(User.class)
	.get();
assertEquals("john", u.getLogin());
```

then assertion error message does not have good enough information which makes development bit harder (`$Error@5bb0122]`)

```
[ERROR]   GraphQlTests.testGetUser:26 Response has 1 unexpected error(s) of 1 total. If expected, please filter them out: [org.springframework.graphql.support.DefaultExecutionGraphQlResponse$Error@5bb0122]
Request: document='{user(login: "john"){{ login status} }'
```

I am proposing a simple change to improve the readability. Here is the result:

```
[ERROR] Failures:
[ERROR]   GraphQlTests.testGetUser:34 Response has 1 unexpected error(s) of 1 total. If expected, please filter them out: [InvalidSyntaxError{ message=Invalid Syntax : offending token '{' at line 1 column 22 ,offendingToken={ ,locations=[SourceLocation{line=1, column=22}] ,sourcePreview={user(login: "john"){{ login status} }
}]
Request: document='{user(login: "john"){{ login status} }'
```