### PR TITLE
Fix typo in Javadoc of ExecutionGraphQlService

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/ExecutionGraphQlService.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/ExecutionGraphQlService.java
@@ -19,7 +19,7 @@ package org.springframework.graphql;
 import reactor.core.publisher.Mono;
 
 /**
- * Strategy to execute a GraphQL request by inoking GraphQL Java.
+ * Strategy to execute a GraphQL request by invoking GraphQL Java.
  *
  * @author Rossen Stoyanchev
  * @since 1.0.0


### PR DESCRIPTION
This change maybe trivial.