### PR TITLE
Fix NPE when GraphQL argument is a list with a null element

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/GraphQlArgumentBinder.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/GraphQlArgumentBinder.java
@@ -213,7 +213,7 @@ public class GraphQlArgumentBinder {
 		int i = 0;
 		for (Object rawValue : rawCollection) {
 			segments.push("[" + i++ + "]");
-			if (elementClass.isAssignableFrom(rawValue.getClass())) {
+			if (rawValue == null || elementClass.isAssignableFrom(rawValue.getClass())) {
 				collection.add((T) rawValue);
 			}
 			else if (rawValue instanceof Map) {

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/GraphQlArgumentBinderTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/GraphQlArgumentBinderTests.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
+import org.assertj.core.api.CollectionAssert;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.core.ResolvableType;
@@ -281,6 +282,44 @@ class GraphQlArgumentBinderTests {
 		assertThat(((ItemSetHolder) result).getItems()).hasSize(5);
 	}
 
+	@Test
+	@SuppressWarnings("unchecked")
+	void list() throws Exception {
+		Object result = this.binder.bind(
+				environment("{\"key\": [\"1\", \"2\", \"3\"]}"),
+				"key",
+				ResolvableType.forClassWithGenerics(List.class, String.class)
+		);
+
+		assertThat(result).isNotNull().isInstanceOf(List.class);
+		new CollectionAssert<>((List<String>) result).containsExactly("1", "2", "3");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void listWithNullItem() throws Exception {
+		Object result = this.binder.bind(
+				environment("{\"key\": [\"1\", null, \"3\"]}"),
+				"key",
+				ResolvableType.forClassWithGenerics(List.class, String.class)
+		);
+
+		assertThat(result).isNotNull().isInstanceOf(List.class);
+		new CollectionAssert<>((List<String>) result).containsExactly("1", null, "3");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void emptyList() throws Exception {
+		Object result = this.binder.bind(
+				environment("{\"key\": []}"),
+				"key",
+				ResolvableType.forClassWithGenerics(List.class, String.class)
+		);
+
+		assertThat(result).isNotNull().isInstanceOf(List.class);
+		new CollectionAssert<>((List<String>) result).isEmpty();
+	}
 
 	@SuppressWarnings("unchecked")
 	private DataFetchingEnvironment environment(String jsonPayload) throws JsonProcessingException {


### PR DESCRIPTION
In case of collection-argument with nullable items.

Passing null items in collection-argument causes NPE in `org.springframework.graphql.data.GraphQlArgumentBinder#createCollection`: `Cannot invoke "Object.getClass()" because "rawValue" is null`.

Test case:
Schema:
```GraphQL
type Query {
    theData(idList: [ID]!): [String]!
}
```
Query:
```GraphQL
{
  theData(idList: ["123", null, "234"])
}
```