### PR TITLE
Adds the option to use a pre configured RSocketRequester

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/client/DefaultRSocketGraphQlClientBuilder.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/client/DefaultRSocketGraphQlClientBuilder.java
@@ -45,6 +45,8 @@ final class DefaultRSocketGraphQlClientBuilder
 
 	private final RSocketRequester.Builder requesterBuilder;
 
+	private RSocketRequester rSocketRequester;
+
 	@Nullable
 	private ClientTransport clientTransport;
 
@@ -112,6 +114,12 @@ final class DefaultRSocketGraphQlClientBuilder
 	}
 
 	@Override
+	public DefaultRSocketGraphQlClientBuilder rsocketRequester(RSocketRequester rSocketRequester) {
+		this.rSocketRequester = rSocketRequester;
+		return this;
+	}
+
+	@Override
 	public RSocketGraphQlClient build() {
 
 		// Pass the codecs to the parent for response decoding
@@ -120,8 +128,14 @@ final class DefaultRSocketGraphQlClientBuilder
 			builder.encoders(encoders -> setJsonEncoder(CodecDelegate.findJsonEncoder(encoders)));
 		});
 
-		Assert.state(this.clientTransport != null, "Neither WebSocket nor TCP networking configured");
-		RSocketRequester requester = this.requesterBuilder.transport(this.clientTransport);
+		RSocketRequester requester;
+
+		if(this.rSocketRequester != null){
+			requester = this.rSocketRequester;
+		} else {
+			Assert.state(this.clientTransport != null, "Neither WebSocket nor TCP networking configured");
+			requester = this.requesterBuilder.transport(this.clientTransport);
+		}
 		RSocketGraphQlTransport graphQlTransport = new RSocketGraphQlTransport(this.route, requester, getJsonDecoder());
 
 		return new DefaultRSocketGraphQlClient(

--- a/spring-graphql/src/main/java/org/springframework/graphql/client/DefaultRSocketGraphQlClientBuilder.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/client/DefaultRSocketGraphQlClientBuilder.java
@@ -52,6 +52,7 @@ final class DefaultRSocketGraphQlClientBuilder
 	private Publisher<List<LoadbalanceTarget>> targetPublisher;
 
 	private LoadbalanceStrategy loadbalanceStrategy;
+
 	@Nullable
 	private ClientTransport clientTransport;
 

--- a/spring-graphql/src/main/java/org/springframework/graphql/client/DefaultRSocketGraphQlClientBuilder.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/client/DefaultRSocketGraphQlClientBuilder.java
@@ -130,8 +130,10 @@ final class DefaultRSocketGraphQlClientBuilder
 
 		RSocketRequester requester;
 
-		if(this.rSocketRequester != null){
+		if (this.rSocketRequester != null) {
 			requester = this.rSocketRequester;
+			// Sets decoder for subscription error handling
+			setJsonDecoder(DefaultJackson2Codecs.decoder());
 		} else {
 			Assert.state(this.clientTransport != null, "Neither WebSocket nor TCP networking configured");
 			requester = this.requesterBuilder.transport(this.clientTransport);

--- a/spring-graphql/src/main/java/org/springframework/graphql/client/RSocketGraphQlClient.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/client/RSocketGraphQlClient.java
@@ -130,6 +130,12 @@ public interface RSocketGraphQlClient extends GraphQlClient {
 		B rsocketRequester(Consumer<RSocketRequester.Builder> requester);
 
 		/**
+		 * Assigns a {@code RSocketRequester} to use.
+		 * @return the same builder instance
+		 */
+		B rsocketRequester(RSocketRequester rSocketRequester);
+
+		/**
 		 * Build the {@code RSocketGraphQlClient} instance.
 		 */
 		@Override

--- a/spring-graphql/src/main/java/org/springframework/graphql/client/RSocketGraphQlClient.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/client/RSocketGraphQlClient.java
@@ -17,10 +17,14 @@
 package org.springframework.graphql.client;
 
 import java.net.URI;
+import java.util.List;
 import java.util.function.Consumer;
 
 import io.rsocket.core.RSocketClient;
+import io.rsocket.loadbalance.LoadbalanceStrategy;
+import io.rsocket.loadbalance.LoadbalanceTarget;
 import io.rsocket.transport.ClientTransport;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 import org.springframework.messaging.rsocket.RSocketRequester;
@@ -130,10 +134,18 @@ public interface RSocketGraphQlClient extends GraphQlClient {
 		B rsocketRequester(Consumer<RSocketRequester.Builder> requester);
 
 		/**
-		 * Assigns a {@code RSocketRequester} to use.
+		 * Build an {@link RSocketRequester} with an
+		 * {@link io.rsocket.loadbalance.LoadbalanceRSocketClient} that will
+		 * connect to one of the given targets selected through the given
+		 * {@link io.rsocket.loadbalance.LoadbalanceRSocketClient}.
+		 * @param targetPublisher a {@code Publisher} that supplies a list of
+		 * target transports to loadbalance against; the given list may be
+		 * periodically updated by the {@code Publisher}.
+		 * @param loadbalanceStrategy the strategy to use for selecting from
+		 * the list of loadbalance targets.
 		 * @return the same builder instance
 		 */
-		B rsocketRequester(RSocketRequester rSocketRequester);
+		B transports(Publisher<List<LoadbalanceTarget>> targetPublisher, LoadbalanceStrategy loadbalanceStrategy);
 
 		/**
 		 * Build the {@code RSocketGraphQlClient} instance.


### PR DESCRIPTION
This PR adds support to reuse a RSocketRequester object, with the purpose of reusing its load balancing features, and to avoid duplicating code in case the applciations uses GraphQL over RSocket and RSocket clients.

As described on Issue #497