### PR TITLE
Add actual elements to message of `containsAll`

### DIFF
--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
@@ -563,9 +563,11 @@ final class DefaultGraphQlTester implements GraphQlTester {
 		public EntityList<E> containsExactly(E... values) {
 			doAssert(() -> {
 				List<E> expected = Arrays.asList(values);
+				List<E> actual = getEntity();
 				AssertionErrors.assertTrue(
-						"List at path '" + getPath() + "' should have contained exactly " + expected,
-						getEntity().equals(expected));
+						"List at path '" + getPath() + "' should have contained exactly " + expected + ", " +
+								"but did contain " + actual,
+						actual.equals(expected));
 			});
 			return this;
 		}

--- a/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
+++ b/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
@@ -179,7 +179,8 @@ public class GraphQlTesterTests extends GraphQlTesterTestSupport {
 
 		assertThatThrownBy(() -> entityList.containsExactly(leia, han))
 				.as("Should be exactly the same order")
-				.hasMessageStartingWith("List at path 'me.friends' should have contained exactly");
+				.hasMessageStartingWith("List at path 'me.friends' should have contained exactly")
+				.hasMessageContaining("but did contain ");
 
 		response.path("me.friends")
 				.entityList(new ParameterizedTypeReference<MovieCharacter>() {})


### PR DESCRIPTION
To make the message more useful I now often replace the matcher with a variant of `isEqualTo` because that shows me a message with what the actual items are. 

With the updated message that's no longer necessary.