### PR TITLE
Controller method cannot return CompletableFuture if any method argument is `Mono`

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/DataFetcherHandlerMethod.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/DataFetcherHandlerMethod.java
@@ -16,6 +16,7 @@
 package org.springframework.graphql.data.method.annotation.support;
 
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 
@@ -136,12 +137,16 @@ public class DataFetcherHandlerMethod extends InvocableHandlerMethodSupport {
 					if (result instanceof Mono) {
 						return (Mono<?>) result;
 					}
-					else if (result instanceof Flux) {
+
+					if (result instanceof Flux) {
 						return Flux.from((Flux<?>) result).collectList();
 					}
-					else {
-						return Mono.justOrEmpty(result);
+
+					if (result instanceof CompletableFuture<?>) {
+						return Mono.fromFuture((CompletableFuture<?>) result);
 					}
+
+					return Mono.justOrEmpty(result);
 				});
 	}
 


### PR DESCRIPTION
When returning `CompletableFuture`s from datafetchers we sometimes encounter an error in the lines of `Unknown value 'java.util.concurrent.CompletableFuture@e77cd7a[Completed normally]'`.
By converting the future to a mono it should be handled properly.

This is probably not a complete solution, and maybe the returned `CompletableFuture` should be handled somewhere different, but this at least seems to solve the issue.