### PR TITLE
Support keep-alive pings in WebSocketGraphQlClient

### DIFF
--- a/spring-graphql-docs/src/docs/asciidoc/includes/client.adoc
+++ b/spring-graphql-docs/src/docs/asciidoc/includes/client.adoc
@@ -120,6 +120,13 @@ existing `WebSocketGraphQlClient` to create a new instance with customized setti
 
 ----
 
+If you'd like the client to send regular graphql ping messages to the server, you can add these by adding `keepalive(long seconds)` to the builder
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+    WebSocketGraphQlClient graphQlClient = WebSocketGraphQlClient.builder(url, client)
+        .keepalive(30)
+        .build();
+----
 
 [[client.websocketgraphqlclient.interceptor]]
 ==== Interceptor

--- a/spring-graphql/src/main/java/org/springframework/graphql/client/WebSocketGraphQlClient.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/client/WebSocketGraphQlClient.java
@@ -65,6 +65,16 @@ public interface WebSocketGraphQlClient extends WebGraphQlClient {
 	}
 
 	/**
+	 * Create a {@link WebSocketGraphQlClient}.
+	 * @param url the GraphQL endpoint URL
+	 * @param webSocketClient the underlying transport client to use
+	 * @param keepalive the delay in seconds between sending ping messages, or 0 to disable
+	 */
+	static WebSocketGraphQlClient create(URI url, WebSocketClient webSocketClient, long keepalive) {
+		return builder(url, webSocketClient).keepalive(keepalive).build();
+	}
+
+	/**
 	 * Return a builder for a {@link WebSocketGraphQlClient}.
 	 * @param url the GraphQL endpoint URL
 	 * @param webSocketClient the underlying transport client to use
@@ -77,9 +87,29 @@ public interface WebSocketGraphQlClient extends WebGraphQlClient {
 	 * Return a builder for a {@link WebSocketGraphQlClient}.
 	 * @param url the GraphQL endpoint URL
 	 * @param webSocketClient the underlying transport client to use
+	 * @param keepalive the delay in seconds between sending ping messages, or 0 to disable
+	 */
+	static Builder<?> builder(String url, WebSocketClient webSocketClient, long keepalive) {
+		return new DefaultWebSocketGraphQlClientBuilder(url, webSocketClient, keepalive);
+	}
+
+	/**
+	 * Return a builder for a {@link WebSocketGraphQlClient}.
+	 * @param url the GraphQL endpoint URL
+	 * @param webSocketClient the underlying transport client to use
 	 */
 	static Builder<?> builder(URI url, WebSocketClient webSocketClient) {
 		return new DefaultWebSocketGraphQlClientBuilder(url, webSocketClient);
+	}
+
+	/**
+	 * Return a builder for a {@link WebSocketGraphQlClient}.
+	 * @param url the GraphQL endpoint URL
+	 * @param webSocketClient the underlying transport client to use
+	 * @param keepalive the delay in seconds between sending ping messages, or 0 to disable
+	 */
+	static Builder<?> builder(URI url, WebSocketClient webSocketClient, long keepalive) {
+		return new DefaultWebSocketGraphQlClientBuilder(url, webSocketClient, keepalive);
 	}
 
 
@@ -93,6 +123,8 @@ public interface WebSocketGraphQlClient extends WebGraphQlClient {
 		 */
 		@Override
 		WebSocketGraphQlClient build();
+
+		Builder<B> keepalive(long keepalive);
 
 	}
 

--- a/spring-graphql/src/test/java/org/springframework/graphql/client/MockGraphQlWebSocketServer.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/client/MockGraphQlWebSocketServer.java
@@ -110,6 +110,8 @@ public final class MockGraphQlWebSocketServer implements WebSocketHandler {
 										GraphQlWebSocketMessage.complete(id));
 			case COMPLETE:
 				return Flux.empty();
+			case PING:
+				return Mono.just(GraphQlWebSocketMessage.pong(null));
 			default:
 				return Flux.error(new IllegalStateException("Unexpected message: " + message));
 		}

--- a/spring-graphql/src/test/java/org/springframework/graphql/client/WebSocketGraphQlTransportTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/client/WebSocketGraphQlTransportTests.java
@@ -227,7 +227,7 @@ public class WebSocketGraphQlTransportTests {
 
 
 		WebSocketGraphQlTransport transport = new WebSocketGraphQlTransport(
-				URI.create("/"), HttpHeaders.EMPTY, client, ClientCodecConfigurer.create(), interceptor, 3);
+				URI.create("/"), HttpHeaders.EMPTY, client, ClientCodecConfigurer.create(), interceptor, KEEPALIVE);
 
 		transport.start().block(TIMEOUT);
 


### PR DESCRIPTION
Added a keepalive option to the WebSocketGraphQlClient builder. This gets passed down to the WebSocketGraphQlTransport which then sends graphql ping messages over the websocket every keepalive seconds.

I've added basic handling to accept the pong messages back, but no processing or checks that a pong response is received in a timely manner, similar to the graphql-ws client library.