### PR TITLE
Replace ExtendWith and ContextConfiguration with SpringJUnitConfig

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,0 @@
-# Enable auto-env through the sdkman_auto_env config
-# Add key=value pairs of SDKs to use below
-java=8.0.322-librca

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/query/jpa/QueryByExampleDataFetcherJpaTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/query/jpa/QueryByExampleDataFetcherJpaTests.java
@@ -156,7 +156,7 @@ class QueryByExampleDataFetcherJpaTests {
 	}
 
 	@Disabled("Pending https://github.com/spring-projects/spring-data-jpa/issues/2327")
-			@Test
+	@Test
 	void shouldFetchSingleItemsWithDtoProjection() {
 		Book book = new Book(42L, "Hitchhiker's Guide to the Galaxy", new Author(0L, "Douglas", "Adams"));
 		repository.save(book);

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/query/jpa/QueryByExampleDataFetcherJpaTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/query/jpa/QueryByExampleDataFetcherJpaTests.java
@@ -30,7 +30,6 @@ import jakarta.persistence.EntityManagerFactory;
 import graphql.schema.DataFetcher;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,8 +52,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,8 +63,7 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for {@link QueryByExampleDataFetcher}.
  */
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration
+@SpringJUnitConfig
 class QueryByExampleDataFetcherJpaTests {
 
 	@Autowired
@@ -159,7 +156,7 @@ class QueryByExampleDataFetcherJpaTests {
 	}
 
 	@Disabled("Pending https://github.com/spring-projects/spring-data-jpa/issues/2327")
-	@Test
+			@Test
 	void shouldFetchSingleItemsWithDtoProjection() {
 		Book book = new Book(42L, "Hitchhiker's Guide to the Galaxy", new Author(0L, "Douglas", "Adams"));
 		repository.save(book);

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/query/mongo/QueryByExampleDataFetcherMongoDbTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/query/mongo/QueryByExampleDataFetcherMongoDbTests.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import com.mongodb.client.MongoClients;
 import graphql.schema.DataFetcher;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -51,8 +50,7 @@ import org.springframework.graphql.server.WebGraphQlRequest;
 import org.springframework.graphql.server.WebGraphQlResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
@@ -62,8 +60,7 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for {@link QueryByExampleDataFetcher}.
  */
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration
+@SpringJUnitConfig
 @Testcontainers(disabledWithoutDocker = true)
 class QueryByExampleDataFetcherMongoDbTests {
 

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/query/mongo/QueryByExampleDataFetcherReactiveMongoDbTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/query/mongo/QueryByExampleDataFetcherReactiveMongoDbTests.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 import com.mongodb.reactivestreams.client.MongoClients;
 import graphql.schema.DataFetcher;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -50,16 +49,14 @@ import org.springframework.graphql.server.WebGraphQlHandler;
 import org.springframework.graphql.server.WebGraphQlResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for {@link QueryByExampleDataFetcher}.
  */
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration
+@SpringJUnitConfig
 @Testcontainers(disabledWithoutDocker = true)
 class QueryByExampleDataFetcherReactiveMongoDbTests {
 


### PR DESCRIPTION
Came across an outdated `.sdkmanrc` file that's not been updated since the switch to Java 17; but as that's not enough to warrant a pull request I figured also pick up some quick automated fixes to the test context setup, based on https://github.com/openrewrite/rewrite-spring/issues/296.
