### PR TITLE
Proposal: print actual value in `containsExactly` assertion message

### DIFF
--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
@@ -565,7 +565,7 @@ final class DefaultGraphQlTester implements GraphQlTester {
 			doAssert(() -> {
 				List<E> expected = Arrays.asList(values);
 				AssertionErrors.assertTrue(
-						"Expecting list " + getEntity() + " at path '" + getPath() + "' to contain exactly " + expected,
+						"Expecting list " + getEntity() + " at path '" + getPath() + "' to contain exactly " + expected + ", but contains " + getEntity(),
 						getEntity().equals(expected));
 			});
 			return this;

--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
@@ -541,7 +541,7 @@ final class DefaultGraphQlTester implements GraphQlTester {
 			doAssert(() -> {
 				List<E> expected = Arrays.asList(values);
 				AssertionErrors.assertTrue(
-						"Expecting list " + getEntity() + " at path '" + getPath() + "' to contain " + expected,
+						"Expecting list " + getEntity() + " at path '" + getPath() + "' to contain " + expected + ", but contains " + getEntity(),
 						getEntity().containsAll(expected));
 			});
 			return this;


### PR DESCRIPTION
Without this change debugging failing assertions requires changing the test implementation.