### PR TITLE
Add WebGraphQlRequest with direct passing query, operationName, variables

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/server/WebGraphQlRequest.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/WebGraphQlRequest.java
@@ -46,6 +46,17 @@ public class WebGraphQlRequest extends DefaultExecutionGraphQlRequest implements
 
 	private final HttpHeaders headers;
 
+    public WebGraphQlRequest(URI uri, HttpHeaders headers, String query, String operationName,
+                             Map<String, Object> variables, Map<String, Object> extensions, String id,
+                             @Nullable Locale locale) {
+        super(query, operationName, variables, extensions, id, locale);
+
+        Assert.notNull(uri, "URI is required'");
+        Assert.notNull(headers, "HttpHeaders is required'");
+
+        this.uri = UriComponentsBuilder.fromUri(uri).build(true);
+        this.headers = headers;
+    }
 
 	/**
 	 * Create an instance.


### PR DESCRIPTION
It is small part of https://github.com/spring-projects/spring-graphql/pull/430 whichwill help to create multipart GraphQlHttpHandler

cc @rstoyanchev 