### PR TITLE
Add WebGraphQlRequest constructor

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/server/WebGraphQlRequest.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/WebGraphQlRequest.java
@@ -96,6 +96,36 @@ public class WebGraphQlRequest extends DefaultExecutionGraphQlRequest implements
 		this.attributes = Collections.unmodifiableMap(attributes);
 	}
 
+    /**
+     * Create an instance by provided fields.
+     * @param uri the URL for the HTTP request or WebSocket handshake
+     * @param headers the HTTP request headers
+     * @param cookies the HTTP request cookies
+     * @param attributes request attributes
+     * @param query the GraphQL's document
+     * @param operationName the GraphQL's operation name
+     * @param variables the GraphQL's variables
+     * @param extensions the GraphQL's extensions
+     * @param id an identifier for the GraphQL request
+     * @param locale the locale from the HTTP request, if any
+     * @since 1.2.0
+     */
+    public WebGraphQlRequest(
+            URI uri, HttpHeaders headers, @Nullable MultiValueMap<String, HttpCookie> cookies,
+            Map<String, Object> attributes, String query, String operationName, Map<String, Object> variables,
+            Map<String, Object> extensions, String id, @Nullable Locale locale) {
+
+        super(query, operationName, variables, extensions, id, locale);
+
+        Assert.notNull(uri, "URI is required'");
+        Assert.notNull(headers, "HttpHeaders is required'");
+
+        this.uri = UriComponentsBuilder.fromUri(uri).build(true);
+        this.headers = headers;
+        this.cookies = (cookies != null ? CollectionUtils.unmodifiableMultiValueMap(cookies) : EMPTY_COOKIES);
+        this.attributes = Collections.unmodifiableMap(attributes);
+    }
+
 	@SuppressWarnings("unchecked")
 	private static <T> T getKey(String key, Map<String, Object> body) {
 		if (key.equals("query") && !StringUtils.hasText((String) body.get(key))) {


### PR DESCRIPTION
With direct passing query, operationName, variables. It will help to create multipart GraphQlHttpHandler

It is small part of https://github.com/spring-projects/spring-graphql/pull/430 which will help to create multipart GraphQlHttpHandler