### PR TITLE
Allow users to add Argument Resolvers

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/AnnotatedControllerConfigurer.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/AnnotatedControllerConfigurer.java
@@ -193,7 +193,7 @@ public class AnnotatedControllerConfigurer implements ApplicationContextAware, I
 		this.customArgumentResolvers.add(resolver);
 	}
 
-	HandlerMethodArgumentResolverComposite getArgumentResolvers() {
+	public HandlerMethodArgumentResolverComposite getArgumentResolvers() {
 		Assert.notNull(this.argumentResolvers,
 				"HandlerMethodArgumentResolverComposite is not yet initialized, was afterPropertiesSet called?");
 		return this.argumentResolvers;


### PR DESCRIPTION
`getArgumentResolvers` is not used anywhere else, it seems that the public setting is forgotten here?