### PR TITLE
Add ValueExtractor for ArgumentValue

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/ArgumentValueExtractor.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/ArgumentValueExtractor.java
@@ -1,0 +1,16 @@
+package org.springframework.graphql.data;
+
+import jakarta.validation.valueextraction.ExtractedValue;
+import jakarta.validation.valueextraction.UnwrapByDefault;
+import jakarta.validation.valueextraction.ValueExtractor;
+
+@UnwrapByDefault
+public class ArgumentValueExtractor implements ValueExtractor<ArgumentValue<@ExtractedValue ?>> {
+
+    @Override
+    public void extractValues(ArgumentValue<?> originalValue, ValueReceiver receiver) {
+        if (originalValue.isPresent()) {
+            receiver.value(null, originalValue.value());
+        }
+    }
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ArgumentValueExtractor.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ArgumentValueExtractor.java
@@ -1,8 +1,9 @@
-package org.springframework.graphql.data;
+package org.springframework.graphql.data.method.annotation.support;
 
 import jakarta.validation.valueextraction.ExtractedValue;
 import jakarta.validation.valueextraction.UnwrapByDefault;
 import jakarta.validation.valueextraction.ValueExtractor;
+import org.springframework.graphql.data.ArgumentValue;
 
 @UnwrapByDefault
 public class ArgumentValueExtractor implements ValueExtractor<ArgumentValue<@ExtractedValue ?>> {

--- a/spring-graphql/src/main/resources/META-INF/services/jakarta.validation.valueextraction.ValueExtractor
+++ b/spring-graphql/src/main/resources/META-INF/services/jakarta.validation.valueextraction.ValueExtractor
@@ -1,1 +1,1 @@
-org.springframework.graphql.data.ArgumentValueExtractor
+org.springframework.graphql.data.method.annotation.support.ArgumentValueExtractor

--- a/spring-graphql/src/main/resources/META-INF/services/jakarta.validation.valueextraction.ValueExtractor
+++ b/spring-graphql/src/main/resources/META-INF/services/jakarta.validation.valueextraction.ValueExtractor
@@ -1,0 +1,1 @@
+org.springframework.graphql.data.ArgumentValueExtractor

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/ValidationHelperTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/ValidationHelperTests.java
@@ -27,6 +27,7 @@ import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Valid;
 import jakarta.validation.Validation;
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.IterableAssert;
@@ -34,6 +35,7 @@ import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.graphql.data.ArgumentValue;
 import org.springframework.graphql.data.method.HandlerMethod;
 import org.springframework.validation.annotation.Validated;
 
@@ -68,6 +70,9 @@ class ValidationHelperTests {
 
 		BiConsumer<Object, Object[]> validator2 = createValidator(MyBean.class, "myValidatedParameterMethod");
 		assertViolation(() -> validator2.accept(bean, new Object[] {new ConstrainedInput(100)}), "integerValue");
+
+		BiConsumer<Object, Object[]> validator3 = createValidator(MyBean.class, "myValidArgumentValue");
+		assertViolation(() -> validator3.accept(bean, new Object[] {ArgumentValue.ofNullable("")}), "myValidArgumentValue.arg0");
 	}
 
 	@Test
@@ -152,6 +157,10 @@ class ValidationHelperTests {
 		}
 
 		public Object myValidatedParameterMethod(@Validated ConstrainedInput input) {
+			return null;
+		}
+
+		public Object myValidArgumentValue(@Valid ArgumentValue<@NotBlank String> arg0) {
 			return null;
 		}
 	}


### PR DESCRIPTION
Validation annotations on ArgumentValue are not working as there's no ValueExtractor provided.
For example, this code `ArgumentValue<@NotBlank @Size(min = 2, max = 500) String> name` will not work as expected.

Adding ValueExtractor will solve the issue

```java
@UnwrapByDefault
public class ArgumentValueExtractor implements ValueExtractor<ArgumentValue<@ExtractedValue ?>> {

    @Override
    public void extractValues(ArgumentValue<?> originalValue, ValueReceiver receiver) {
        if (originalValue.isPresent()) {
            receiver.value(null, originalValue.value());
        }
    }
}
```

#736