### PR TITLE
Correctly retrieve operation name from the body of the request

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/server/WebGraphQlRequest.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/WebGraphQlRequest.java
@@ -105,9 +105,9 @@ public class WebGraphQlRequest extends DefaultExecutionGraphQlRequest implements
 
 	@Nullable
 	private static String getOperation(Map<String, Object> body) {
-		Object value = body.get("operation");
+		Object value = body.get("operationName");
 		if (value != null && !(value instanceof String)) {
-			throw new ServerWebInputException("Invalid value for 'operation'");
+			throw new ServerWebInputException("Invalid value for 'operationName'");
 		}
 		return (String) value;
 	}

--- a/spring-graphql/src/test/java/org/springframework/graphql/server/WebGraphQlRequestTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/server/WebGraphQlRequestTests.java
@@ -39,7 +39,7 @@ public class WebGraphQlRequestTests {
 	void invalidBody() {
 		testInvalidBody(Map.of());
 		testInvalidBody(Map.of("query", Collections.emptyMap()));
-		testInvalidBody(Map.of("query", "query { foo }", "operation", Collections.emptyMap()));
+		testInvalidBody(Map.of("query", "query { foo }", "operationName", Collections.emptyMap()));
 		testInvalidBody(Map.of("query", "query { foo }", "variables", "not-a-map"));
 		testInvalidBody(Map.of("query", "query { foo }", "extensions", "not-a-map"));
 	}


### PR DESCRIPTION
In https://github.com/spring-projects/spring-graphql/commit/1406ca2218c7ddc56d839f65bc32d22e7f8c2631 the body key was changed from `operationName` to `operation`, which I think was an error, because now for example setting the operation name on the `WebGraphQlTester` doesn't work anymore.

I've look into adding a test for the faulty behavior, but not sure where to add that.