### PR TITLE
Fix typo in README.md and the Testing section of docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project is governed by the [Spring Code of Conduct](CODE_OF_CONDUCT.adoc). 
 ## Documentation
 
 This project has reference documentation ([published](https://docs.spring.io/spring-graphql/docs/current-SNAPSHOT/reference/html/) and [source](spring-graphql-docs/src/docs/asciidoc)), an
-[API reference](https://docs.spring.io/spring-graphql/docs/current-SNAPSHOT/api/). The are [samples](https://github.com/spring-projects/spring-graphql/tree/1.0.x/samples) in the 1.0.x branch that will be [moved out](https://github.com/spring-projects/spring-graphql/issues/208) into a separate repository.
+[API reference](https://docs.spring.io/spring-graphql/docs/current-SNAPSHOT/api/). There are [samples](https://github.com/spring-projects/spring-graphql/tree/1.0.x/samples) in the 1.0.x branch that will be [moved out](https://github.com/spring-projects/spring-graphql/issues/208) into a separate repository.
 
 ## Continuous Integration Builds
 

--- a/spring-graphql-docs/src/docs/asciidoc/includes/testing.adoc
+++ b/spring-graphql-docs/src/docs/asciidoc/includes/testing.adoc
@@ -49,7 +49,7 @@ following extensions:
 To create a `GraphQlTester` that performs tests on the server side, without a client:
 
 - <<testing.graphqlservicetester, ExecutionGraphQlServiceTester>>
-- <<testing.webgraphqltester, WebGraphQlServiceTester>>
+- <<testing.webgraphqltester, WebGraphQlTester>>
 
 Each defines a `Builder` with options relevant to the transport. All builders extend
 from a common, base GraphQlTester <<testing.graphqltester.builder, `Builder`>> with
@@ -263,7 +263,7 @@ The builder for this extension allows you to define HTTP request details:
 			.build();
 ----
 
-Once `WebGraphQlServiceTester` is created, you can begin to
+Once `WebGraphQlTester` is created, you can begin to
 <<testing.requests, execute requests>> using the same API, independent of the underlying
 transport.
 


### PR DESCRIPTION
@pivotal-cla This is an Obvious Fix.

1. There is a simple typo in README.md.
2. In the Testing section of the docs, it mentions `WebGraphQlServiceTester` which is not the actual name of the interface in the source code; it is `WebGraphQlTester`. This should be fixed as it can cause confusion.