### PR TITLE
Raise AuthenticationCredentialsNotFoundException if Principal is not present and declared as not optional

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/BatchLoaderHandlerMethod.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/BatchLoaderHandlerMethod.java
@@ -145,7 +145,7 @@ public class BatchLoaderHandlerMethod extends InvocableHandlerMethodSupport {
 			return null;
 		}
 		else if (springSecurityPresent && Principal.class.isAssignableFrom(parameter.getParameterType())) {
-			return PrincipalMethodArgumentResolver.doResolve();
+			return PrincipalMethodArgumentResolver.doResolve(parameter.isOptional());
 		}
 		else {
 			throw new IllegalStateException(formatArgumentError(parameter, "Unexpected argument type."));


### PR DESCRIPTION
The issue with a non-null principal argument is more visible in Kotlin then it is in Java; in Java even when a function argument is annotated as non-null, it still accepts a null value for that parameter, but in Kotlin this results in a "can not assign null to non-null parameter" error.

By throwing a security error when the argument is non-null, and the principal isn't present in the security context, authentication errors can be handler in an exception resolver class, instead of resulting in an arbitrary internal error.

Fixes #714 