### PR TITLE
Use ScrollPosition.offset() to get initial scroll position

### DIFF
--- a/spring-graphql-docs/modules/ROOT/pages/controllers.adoc
+++ b/spring-graphql-docs/modules/ROOT/pages/controllers.adoc
@@ -433,7 +433,7 @@ public class BookController {
 
 	@QueryMapping
 	public Window<Book> books(ScrollSubrange subrange) {
-		ScrollPosition position = subrange.position().orElse(OffsetScrollPosition.initial())
+		ScrollPosition position = subrange.position().orElse(ScrollPosition.offset());
 		int count = subrange.count().orElse(20);
 		// ...
 	}


### PR DESCRIPTION
`OffsetScrollPosition.initial()` is package protected, so I think `ScrollPosition.offset()` is the right way to create an initial `ScrollPosition`