### PR TITLE
Use isOmitted rather than isPresent in ValueExtractor to allow validation of null arguments

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ArgumentValueValueExtractor.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ArgumentValueValueExtractor.java
@@ -32,7 +32,7 @@ public final class ArgumentValueValueExtractor implements ValueExtractor<Argumen
 
     @Override
     public void extractValues(ArgumentValue<?> argumentValue, ValueReceiver receiver) {
-        if (argumentValue.isPresent()) {
+        if (!argumentValue.isOmitted()) {
             receiver.value(null, argumentValue.value());
         }
     }

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/ValidationHelperTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/ValidationHelperTests.java
@@ -73,6 +73,18 @@ class ValidationHelperTests {
 
 		BiConsumer<Object, Object[]> validator3 = validateFunction(MyBean.class, "myValidArgumentValue");
 		assertViolation(() -> validator3.accept(bean, new Object[] {ArgumentValue.ofNullable("")}), "myValidArgumentValue.arg0");
+
+		// Validate that an explicit null value is validated.
+		assertViolation(() -> validator3.accept(bean, new Object[] {ArgumentValue.ofNullable(null)}), "myValidArgumentValue.arg0");
+	}
+
+	@Test
+	void shouldNotRaiseValidationErrorForOmittedArgumentValue() {
+		MyBean bean = new MyBean();
+
+		// Validate that an omitted value is allowed.
+		BiConsumer<Object, Object[]> validator3 = validateFunction(MyBean.class, "myValidArgumentValue");
+		validator3.accept(bean, new Object[] {ArgumentValue.omitted()});
 	}
 
 	@Test


### PR DESCRIPTION
`isPresent()` returns false, even when an explicit `null` value is supplied. By checking `isOmitted()` instead, we can correctly use validation annotations like `@NotBlank`.

~Will see if I can update the tests for this as well.~ Tests have been updated.