### PR TITLE
Lenient parsing of SourceLocation's line and column in ResponseMapGraphQlResponse

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/client/ResponseMapGraphQlResponse.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/client/ResponseMapGraphQlResponse.java
@@ -16,9 +16,11 @@
 
 package org.springframework.graphql.client;
 
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import graphql.ErrorClassification;
@@ -130,8 +132,23 @@ class ResponseMapGraphQlResponse extends AbstractGraphQlResponse {
 		@SuppressWarnings("unchecked")
 		private static List<SourceLocation> initLocations(Map<String, Object> errorMap) {
 			return ((List<Map<String, Object>>) errorMap.getOrDefault("locations", Collections.emptyList())).stream()
-					.map(map -> new SourceLocation((int) map.get("line"), (int) map.get("column"), (String) map.get("sourceName")))
+					.map(map -> new SourceLocation(
+              objectAsInt(map.get("line")),
+              objectAsInt(map.get("column")),
+              Objects.toString(map.get("sourceName"))
+          ))
 					.collect(Collectors.toList());
+		}
+
+		private static int objectAsInt(Object value) {
+
+			if (value instanceof BigInteger bigInteger) {
+				return bigInteger.intValue();
+			} else if (value instanceof Number number) {
+				return number.intValue();
+			} else {
+				return -1;
+			}
 		}
 
 		@SuppressWarnings("unchecked")

--- a/spring-graphql/src/main/java/org/springframework/graphql/client/ResponseMapGraphQlResponse.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/client/ResponseMapGraphQlResponse.java
@@ -133,10 +133,10 @@ class ResponseMapGraphQlResponse extends AbstractGraphQlResponse {
 		private static List<SourceLocation> initLocations(Map<String, Object> errorMap) {
 			return ((List<Map<String, Object>>) errorMap.getOrDefault("locations", Collections.emptyList())).stream()
 					.map(map -> new SourceLocation(
-              objectAsInt(map.get("line")),
-              objectAsInt(map.get("column")),
-              Objects.toString(map.get("sourceName"))
-          ))
+						objectAsInt(map.get("line")),
+						objectAsInt(map.get("column")),
+						Objects.toString(map.get("sourceName"))
+					))
 					.collect(Collectors.toList());
 		}
 


### PR DESCRIPTION
If the registered `ObjectMapper` has enabled `DeserializationFeature.USE_BIG_INTEGER_FOR_INTS` then the response parsing fails because it assumes `int`.

This checks the field type and converts appropriately, and falls back to `-1` if it is not a number. This might not be the wanted way of handling the fallback. Maybe an exception should be thrown?