### PR TITLE
Add Revved up by Develocity badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img align="left" src="spring-graphql-docs/src/docs/spring-graphql.svg" width="100" height="100"> Spring for GraphQL [![Build status](https://ci.spring.io/api/v1/teams/spring-graphql/pipelines/spring-graphql-1.2.x/jobs/build/badge)](https://ci.spring.io/teams/spring-graphql/pipelines/spring-graphql-1.2.x)
+# <img align="left" src="spring-graphql-docs/src/docs/spring-graphql.svg" width="100" height="100"> Spring for GraphQL [![Build status](https://ci.spring.io/api/v1/teams/spring-graphql/pipelines/spring-graphql-1.2.x/jobs/build/badge)](https://ci.spring.io/teams/spring-graphql/pipelines/spring-graphql-1.2.x) [![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.spring.io/scans?search.rootProjectNames=spring-graphql)
 
 [GraphQL](https://graphql.org/) support for Spring applications with [GraphQL Java](https://github.com/graphql-java/graphql-java).
 


### PR DESCRIPTION
This pull request adds a badge to the project's README to indicate that it uses the Develocity instance hosted at https://ge.spring.io/.

Other Spring projects, such as [Spring Boot](https://github.com/spring-projects/spring-boot?tab=readme-ov-file#spring-boot---) and [Spring Framework](https://github.com/spring-projects/spring-framework?tab=readme-ov-file#-spring-framework--), already have the badge present in their README. 