### PR TITLE
Upgrade to federation-jvm 4.4.0

### DIFF
--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 		api("jakarta.validation:jakarta.validation-api:3.0.2")
 		api("jakarta.persistence:jakarta.persistence-api:3.1.0")
 
-		api("com.apollographql.federation:federation-graphql-java-support:4.3.0")
+		api("com.apollographql.federation:federation-graphql-java-support:4.4.0")
 
 		api("com.google.code.findbugs:jsr305:3.0.2")
 


### PR DESCRIPTION
`v4.4.0` adds support for Federation v2.6 and v2.7. This version also includes performance fix to federating tracing instrumentation (`ftv1`) that skips unnecessary computations.