### PR TITLE
Avoid unnecessary async handling in GraphQlHttpHandler

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/server/webmvc/GraphQlHttpHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/webmvc/GraphQlHttpHandler.java
@@ -17,6 +17,7 @@
 package org.springframework.graphql.server.webmvc;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -106,7 +107,12 @@ public class GraphQlHttpHandler {
 					builder.headers(headers -> headers.putAll(response.getResponseHeaders()));
 					builder.contentType(selectResponseMediaType(serverRequest));
 					return builder.body(response.toMap());
-				});
+				})
+				.cache();
+
+		try {
+			return responseMono.block(Duration.ZERO);
+		} catch (IllegalStateException ignored) {}
 
 		return ServerResponse.async(responseMono);
 	}
@@ -138,5 +144,4 @@ public class GraphQlHttpHandler {
 		}
 		return MediaType.APPLICATION_JSON;
 	}
-
 }

--- a/spring-graphql/src/test/java/org/springframework/graphql/server/webmvc/GraphQlHttpHandlerTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/server/webmvc/GraphQlHttpHandlerTests.java
@@ -122,7 +122,10 @@ public class GraphQlHttpHandlerTests {
 			MockHttpServletRequest servletRequest, GraphQlHttpHandler handler) throws ServletException, IOException {
 
 		ServerRequest request = ServerRequest.create(servletRequest, MESSAGE_READERS);
-		ServerResponse response = ((AsyncServerResponse) handler.handleRequest(request)).block();
+		ServerResponse response = handler.handleRequest(request);
+		if (response instanceof AsyncServerResponse asyncServerResponse) {
+			asyncServerResponse.block();
+		}
 
 		MockHttpServletResponse servletResponse = new MockHttpServletResponse();
 		response.writeTo(servletRequest, servletResponse, new DefaultContext());


### PR DESCRIPTION
In the webmvc GraphQlHttpHandler, return the server response directly if the WebGraphQlHandler returns an already completed Mono. This avoids some extra overhead incurred with async processing.

Some examples of queries that can be serviced without any async are introspection queries, and any query that avoids I/O (e.g., DataFetchers reading from in-memory stores or caches).