### PR TITLE
Add Keep-alive message type.

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/client/WebSocketGraphQlTransport.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/client/WebSocketGraphQlTransport.java
@@ -293,7 +293,7 @@ final class WebSocketGraphQlTransport implements GraphQlTransport {
 								switch (message.resolvedType()) {
 									case NEXT -> graphQlSession.handleNext(message);
 									case PING -> graphQlSession.sendPong(null);
-									case PONG -> { }
+									case PONG, KA -> { }
 									case ERROR -> graphQlSession.handleError(message);
 									case COMPLETE -> graphQlSession.handleComplete(message);
 									default -> throw new IllegalStateException(

--- a/spring-graphql/src/main/java/org/springframework/graphql/server/support/GraphQlWebSocketMessage.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/support/GraphQlWebSocketMessage.java
@@ -220,4 +220,11 @@ public class GraphQlWebSocketMessage {
 		return new GraphQlWebSocketMessage(null, GraphQlWebSocketMessageType.PONG, payload);
 	}
 
+	/**
+	 * Create a {@code "ka"} server message.
+	 */
+	public static GraphQlWebSocketMessage ka() {
+		return new GraphQlWebSocketMessage(null, GraphQlWebSocketMessageType.KA, null);
+	}
+
 }

--- a/spring-graphql/src/main/java/org/springframework/graphql/server/support/GraphQlWebSocketMessageType.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/support/GraphQlWebSocketMessageType.java
@@ -69,7 +69,12 @@ public enum GraphQlWebSocketMessageType {
 	/**
 	 * Indicates the GraphQL message did not have a message type.
 	 */
-	NOT_SPECIFIED("", false);
+	NOT_SPECIFIED("", false),
+
+	/**
+	 * Indicates keep-alive message type.
+	 */
+	KA("ka", false);
 
 
 	private static final GraphQlWebSocketMessageType[] VALUES;

--- a/spring-graphql/src/main/java/org/springframework/graphql/server/webflux/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/webflux/GraphQlWebSocketHandler.java
@@ -184,7 +184,7 @@ public class GraphQlWebSocketHandler implements WebSocketHandler {
 				case PING -> {
 					return Flux.just(this.codecDelegate.encode(session, GraphQlWebSocketMessage.pong(null)));
 				}
-				case PONG, KA -> {
+				case PONG -> {
 					return Flux.empty();
 				}
 				case COMPLETE -> {

--- a/spring-graphql/src/main/java/org/springframework/graphql/server/webflux/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/webflux/GraphQlWebSocketHandler.java
@@ -184,7 +184,7 @@ public class GraphQlWebSocketHandler implements WebSocketHandler {
 				case PING -> {
 					return Flux.just(this.codecDelegate.encode(session, GraphQlWebSocketMessage.pong(null)));
 				}
-				case PONG -> {
+				case PONG, KA -> {
 					return Flux.empty();
 				}
 				case COMPLETE -> {


### PR DESCRIPTION
In these changes, I added a "KA" instance to GraphQlWebSocketMessageType to support this type. Likewise, on the WebSocket client side, in the WebSocketGraphQlTransport class and the handle method, if the type "KA" is received from the server side, the IllegalStateException error will not be thrown, and there is no need for any reaction from the client side. Like receiving a pong message.