### PR TITLE
Allow passing Map of variables in GraphQlTester

### DIFF
--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
@@ -145,6 +145,12 @@ final class DefaultGraphQlTester implements GraphQlTester {
 		}
 
 		@Override
+		public DefaultRequest variable(Map<String, Object> values) {
+			this.variables.putAll(values);
+			return this;
+		}
+
+		@Override
 		public DefaultRequest extension(String name, @Nullable Object value) {
 			this.extensions.put(name, value);
 			return this;

--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/GraphQlTester.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/GraphQlTester.java
@@ -18,6 +18,7 @@ package org.springframework.graphql.test.tester;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -152,6 +153,15 @@ public interface GraphQlTester {
 		 * @return this request spec
 		 */
 		T variable(String name, @Nullable Object value);
+
+		/**
+		 * Add variables.
+		 * @param values the variables to be set
+		 * the variable of the values, possibly {@code null} since GraphQL
+		 * supports providing null value vs not providing a value at all.
+		 * @return this request spec
+		 */
+		T variable(Map<String, Object> values);
 
 		/**
 		 * Add a value for a protocol extension.

--- a/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
+++ b/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
@@ -16,9 +16,7 @@
 
 package org.springframework.graphql.test.tester;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import graphql.GraphqlErrorBuilder;
@@ -151,11 +149,11 @@ public class GraphQlTesterTests extends GraphQlTesterTestSupport {
 		String document = "{me {name, friends}}";
 		getGraphQlService().setDataAsJson(document,
 				"{" +
-				"  \"me\":{" +
-				"      \"name\":\"Luke Skywalker\","
-				+ "    \"friends\":[{\"name\":\"Han Solo\"}, {\"name\":\"Leia Organa\"}]" +
-				"  }" +
-				"}");
+						"  \"me\":{" +
+						"      \"name\":\"Luke Skywalker\","
+						+ "    \"friends\":[{\"name\":\"Han Solo\"}, {\"name\":\"Leia Organa\"}]" +
+						"  }" +
+						"}");
 
 		GraphQlTester.Response response = graphQlTester().document(document).execute();
 
@@ -238,6 +236,39 @@ public class GraphQlTesterTests extends GraphQlTesterTestSupport {
 		assertThat(request.getVariables()).containsEntry("episode", "JEDI");
 		assertThat(request.getVariables()).containsEntry("foo", "bar");
 		assertThat(request.getVariables()).containsEntry("keyOnly", null);
+	}
+
+	@Test
+	void operationNameAndVariablesAsMap() {
+
+		String document = "query HeroNameAndFriends($episode: Episode) {" +
+				"  hero(episode: $episode) {" +
+				"    name"
+				+ "  }" +
+				"}";
+
+		getGraphQlService().setDataAsJson(document, "{\"hero\": {\"name\":\"R2-D2\"}}");
+
+		Map<String, Object> variableMap = new LinkedHashMap<>();
+
+		variableMap.put("episode", Optional.of("JEDI"));
+		variableMap.put("foo", Optional.of("bar"));
+		variableMap.put("keyOnly", Optional.ofNullable(null));
+
+		GraphQlTester.Response response = graphQlTester().document(document)
+				.operationName("HeroNameAndFriends")
+				.variable(variableMap)
+				.execute();
+
+		response.path("hero").entity(MovieCharacter.class).isEqualTo(MovieCharacter.create("R2-D2"));
+
+		ExecutionGraphQlRequest request = getGraphQlService().getGraphQlRequest();
+		assertThat(request.getDocument()).contains(document);
+		assertThat(request.getOperationName()).isEqualTo("HeroNameAndFriends");
+		assertThat(request.getVariables()).hasSize(3);
+		assertThat(request.getVariables()).containsEntry("episode", Optional.of("JEDI"));
+		assertThat(request.getVariables()).containsEntry("foo", Optional.of("bar"));
+		assertThat(request.getVariables()).containsEntry("keyOnly", Optional.ofNullable(null));
 	}
 
 	@Test

--- a/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
+++ b/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
@@ -152,11 +152,11 @@ public class GraphQlTesterTests extends GraphQlTesterTestSupport {
 		String document = "{me {name, friends}}";
 		getGraphQlService().setDataAsJson(document,
 				"{" +
-						"  \"me\":{" +
-						"      \"name\":\"Luke Skywalker\","
-						+ "    \"friends\":[{\"name\":\"Han Solo\"}, {\"name\":\"Leia Organa\"}]" +
-						"  }" +
-						"}");
+				"  \"me\":{" +
+				"      \"name\":\"Luke Skywalker\","
+				+ "    \"friends\":[{\"name\":\"Han Solo\"}, {\"name\":\"Leia Organa\"}]" +
+				"  }" +
+				"}");
 
 		GraphQlTester.Response response = graphQlTester().document(document).execute();
 

--- a/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
+++ b/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
@@ -16,7 +16,10 @@
 
 package org.springframework.graphql.test.tester;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import graphql.GraphqlErrorBuilder;


### PR DESCRIPTION
This PR implements a new method by overriding `variable` to accept a map as parameter. Then adds the values using `putAll` method as bulk. A unit test is also created to assert the change.