### PR TITLE
Update federation-jvm to v5.0.0

### DIFF
--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 		api("jakarta.validation:jakarta.validation-api:3.0.2")
 		api("jakarta.persistence:jakarta.persistence-api:3.1.0")
 
-		api("com.apollographql.federation:federation-graphql-java-support:4.4.0")
+		api("com.apollographql.federation:federation-graphql-java-support:5.0.0")
 		api("com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-shared-core:6.1.5")
 
 		api("com.google.code.findbugs:jsr305:3.0.2")


### PR DESCRIPTION
Federation JVM v5 is now using `graphql-java` v22 which had following breaking changes in behavior

- Apollo `CacheControlInstrumentation` - was using old deprecated instrumentation methods so old version will not work with latest `spring-graphql` version
- there was a breaking change in the schema printing behavior of `@deprecated` information - previously it was always included regardless whether printed schema was filtering  `@deprecated` directive definition. This is an issue for folks relying on self-managed Federation that uses `_service { sdl }` endpoint to obtain subgraph schemas as the supergraph schema would no longer include any deprecation information.