### PR TITLE
Do not apply ContextDataFetcherDecorator to TrivialDataFetcher instances

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/execution/ContextDataFetcherDecorator.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/execution/ContextDataFetcherDecorator.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import graphql.ExecutionInput;
 import graphql.GraphQLContext;
+import graphql.TrivialDataFetcher;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.FieldCoordinates;
@@ -150,6 +151,9 @@ final class ContextDataFetcherDecorator implements DataFetcher<Object> {
 		}
 
 		private boolean applyDecorator(DataFetcher<?> dataFetcher) {
+			if (dataFetcher instanceof TrivialDataFetcher) {
+				return false;
+			}
 			Class<?> type = dataFetcher.getClass();
 			String packageName = type.getPackage().getName();
 			if (packageName.startsWith("graphql.")) {


### PR DESCRIPTION
the `applyDecorator` method is working to exclude things from graphql-java. the TrivialDataFetcher interface is used to know when to perform instrumentation and is a part of the public SPI and should be preserved.

(checkstyle told me to use tabs, but then that looks weirds on GH - apologies if that is wrong!)