### PR TITLE
Add release milestone workflow

### DIFF
--- a/.github/actions/create-github-release/action.yml
+++ b/.github/actions/create-github-release/action.yml
@@ -2,11 +2,15 @@ name: Create GitHub Release
 description: Create the release on GitHub with a changelog
 inputs:
   milestone:
-    description: 'Name of the GitHub milestone for which a release will be created'
+    description: Name of the GitHub milestone for which a release will be created
     required: true
   token:
-    description: 'Token to use for authentication with GitHub'
+    description: Token to use for authentication with GitHub
     required: true
+  pre-release:
+    description: Whether the release is a pre-release (a milestone or release candidate)
+    required: false
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -20,4 +24,4 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       shell: bash
-      run: gh release create ${{ format('v{0}', inputs.milestone) }} --notes-file changelog.md
+      run: gh release create ${{ format('v{0}', inputs.milestone) }} --notes-file changelog.md ${{ inputs.pre-release == 'true' && '--prerelease' || '' }}

--- a/.github/workflows/release-milestone.yml
+++ b/.github/workflows/release-milestone.yml
@@ -1,0 +1,64 @@
+name: Release Milestone
+on:
+  push:
+    tags:
+      - v1.4.0-M[1-9]
+      - v1.4.0-RC[1-9]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+jobs:
+  build-and-stage-release:
+    if: ${{ github.repository == 'spring-projects/spring-graphql' }}
+    name: Build and Stage Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Code
+        uses: actions/checkout@v4
+      - name: Build and Publish
+        id: build-and-publish
+        uses: ./.github/actions/build
+        with:
+          develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
+          publish: true
+      - name: Stage Release
+        uses: spring-io/artifactory-deploy-action@26bbe925a75f4f863e1e529e85be2d0093cac116 # v0.0.1
+        with:
+          uri: 'https://repo.spring.io'
+          username: ${{ secrets.ARTIFACTORY_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          build-name: ${{ format('spring-graphql-{0}', steps.build-and-publish.outputs.version)}}
+          repository: 'libs-staging-local'
+          folder: 'deployment-repository'
+          signing-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          signing-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          artifact-properties: |
+            /**/spring-graphql-docs-*.zip::zip.name=spring-graphql,zip.type=docs,zip.deployed=false
+    outputs:
+      version: ${{ steps.build-and-publish.outputs.version }}
+  promote-release:
+    name: Promote Release
+    needs:
+      - build-and-stage-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JFrog CLI
+        uses: jfrog/setup-jfrog-cli@105617d23456a69a92485207c4f28ae12297581d # v4.2.1
+        env:
+          JF_ENV_SPRING: ${{ secrets.JF_ARTIFACTORY_SPRING }}
+      - name: Promote build
+        run: jfrog rt build-promote ${{ format('spring-graphql-{0}', needs.build-and-stage-release.outputs.version)}} ${{ github.run_number }} libs-milestone-local
+  create-github-release:
+    name: Create GitHub Release
+    needs:
+      - build-and-stage-release
+      - promote-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Create GitHub Release
+        uses: ./.github/actions/create-github-release
+        with:
+          milestone: ${{ needs.build-and-stage-release.outputs.version }}
+          token: ${{ secrets.GH_ACTIONS_REPO_TOKEN }}
+          pre-release: true


### PR DESCRIPTION
This commit adds a dedicated workflow to release a milestone, and publish the changelog with a "pre-release" flag accordingly.

`main` hasn't switched to 1.4 as far as I can see so we can't really merge it just yet but I think it's ready to go once that is.