### PR TITLE
Add `@GraphQlType` Annotation

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/GraphQlType.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/GraphQlType.java
@@ -1,0 +1,24 @@
+package org.springframework.graphql.data.method.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark a class as representing a certain GraphQL type.
+ *
+ * <p>If a class has this annotation, then the default class name extractor in
+ * {@link org.springframework.graphql.execution.ClassNameTypeResolver ClassNameTypeResolver} will use the {@link #value}
+ * from the annotation, rather than the class name.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GraphQlType {
+
+    /**
+     * The GraphQL type name.
+     */
+    String value();
+
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/execution/ClassNameTypeResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/execution/ClassNameTypeResolver.java
@@ -26,6 +26,7 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.TypeResolver;
 
+import org.springframework.graphql.data.method.annotation.GraphQlType;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -34,12 +35,19 @@ import org.springframework.util.Assert;
  * class name of a value returned from a {@code DataFetcher}. If necessary, it
  * walks up the base class and interface hierarchy to find a match.
  *
+ * <p>If the value's type is annotated with {@link GraphQlType}, then the
+ * annotation's value is used rather than the class name.
+ *
  * @author Rossen Stoyanchev
  * @since 1.0.0
  */
 public class ClassNameTypeResolver implements TypeResolver {
 
-	private Function<Class<?>, String> classNameExtractor = Class::getSimpleName;
+	private Function<Class<?>, String> classNameExtractor = type -> {
+		final var annotation = type.getAnnotation(GraphQlType.class);
+		if (annotation != null) return annotation.value();
+		return type.getSimpleName();
+	};
 
 	private final Map<Class<?>, String> mappings = new LinkedHashMap<>();
 

--- a/spring-graphql/src/test/java/org/springframework/graphql/execution/ClassNameTypeResolverTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/execution/ClassNameTypeResolverTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.graphql.GraphQlSetup;
 import org.springframework.graphql.ResponseHelper;
 import org.springframework.graphql.TestExecutionGraphQlService;
+import org.springframework.graphql.data.method.annotation.GraphQlType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -103,7 +104,7 @@ public class ClassNameTypeResolverTests {
 		Mammal mammal = response.toEntity("animals[0]", Dog.class);
 		assertThat(mammal.isHerbivore()).isEqualTo(false);
 
-		Bird bird = response.toEntity("animals[1]", Penguin.class);
+		BirdDataObject bird = response.toEntity("animals[1]", Penguin.class);
 		assertThat(bird.isFlightless()).isEqualTo(true);
 	}
 
@@ -173,7 +174,8 @@ public class ClassNameTypeResolverTests {
 	}
 
 
-	interface Bird extends Animal {
+	@GraphQlType("Bird")
+	interface BirdDataObject extends Animal {
 
 		boolean isFlightless();
 
@@ -203,7 +205,7 @@ public class ClassNameTypeResolverTests {
 	}
 
 
-	static class BaseBird extends BaseAnimal implements Bird {
+	static class BaseBird extends BaseAnimal implements BirdDataObject {
 
 		private final boolean flightless;
 


### PR DESCRIPTION
A Java class name might not perfectly correspond to the corresponding GraphQL type name. In such cases, the default `ClassNameTypeResolver` cannot determine the GraphQL type.

This change introduces an annotation, `@GraphQlType`, which allows you to override the name picked up by the default `classNameExtractor` in `ClassNameTypeResolver`.