### PR TITLE
Remove duplicated wording in federation.adoc

### DIFF
--- a/spring-graphql-docs/modules/ROOT/pages/federation.adoc
+++ b/spring-graphql-docs/modules/ROOT/pages/federation.adoc
@@ -56,8 +56,6 @@ An `@EntityMapping` method can load federated type instances in response to an
 https://www.apollographql.com/docs/federation/subgraph-spec/#understanding-query_entities[_entities query]
 from the federation gateway. For example:
 
-For example:
-
 [source,java,indent=0,subs="verbatim,quotes"]
 ----
 	@Controller


### PR DESCRIPTION
Remove duplicated wording `For example:` in `federation.adoc`.