### PR TITLE
Allow non-nullable types in graphql relay

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/pagination/ConnectionFieldTypeVisitor.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/pagination/ConnectionFieldTypeVisitor.java
@@ -153,7 +153,7 @@ public final class ConnectionFieldTypeVisitor extends GraphQLTypeVisitorStub {
 	@Nullable
 	private static GraphQLObjectType getEdgeType(@Nullable GraphQLFieldDefinition field) {
 		if (getType(field) instanceof GraphQLList listType) {
-			if (listType.getWrappedType() instanceof GraphQLObjectType type) {
+			if (getType(listType.getWrappedType()) instanceof GraphQLObjectType type) {
 				return type;
 			}
 		}
@@ -166,6 +166,14 @@ public final class ConnectionFieldTypeVisitor extends GraphQLTypeVisitorStub {
 			return null;
 		}
 		GraphQLOutputType type = field.getType();
+		return (type instanceof GraphQLNonNull nonNullType) ? nonNullType.getWrappedType() : type;
+	}
+
+	@Nullable
+	private static GraphQLType getType(@Nullable GraphQLType type) {
+		if (type == null) {
+			return null;
+		}
 		return (type instanceof GraphQLNonNull nonNullType) ? nonNullType.getWrappedType() : type;
 	}
 
@@ -185,13 +193,13 @@ public final class ConnectionFieldTypeVisitor extends GraphQLTypeVisitorStub {
 	/**
 	 * {@code DataFetcher} decorator that adapts return values with an adapter.
 	 */
-	private record ConnectionDataFetcher(DataFetcher<?> delegate, ConnectionAdapter adapter) implements DataFetcher<Object> {
+	record ConnectionDataFetcher(DataFetcher<?> delegate, ConnectionAdapter adapter) implements DataFetcher<Object> {
 
 		private static final Connection<?> EMPTY_CONNECTION =
 				new DefaultConnection<>(Collections.emptyList(), new DefaultPageInfo(null, null, false, false));
 
 
-		private ConnectionDataFetcher {
+		ConnectionDataFetcher {
 			Assert.notNull(delegate, "DataFetcher delegate is required");
 			Assert.notNull(adapter, "ConnectionAdapter is required");
 		}

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/pagination/ConnectionFieldTypeVisitorTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/pagination/ConnectionFieldTypeVisitorTests.java
@@ -205,6 +205,44 @@ public class ConnectionFieldTypeVisitorTests {
 			assertThat(actual).isSameAs(dataFetcher);
 		}
 
+		@Test
+		void connectionTypeWithNonNullEdgesIsDecorated() throws Exception {
+			String schemaContent = """
+					type Query {
+						libraries(first: Int, after: String, last: Int, before: String): LibraryConnection!
+					}
+
+					type LibraryConnection {
+						edges: [LibraryEdge!]!
+						pageInfo: PageInfo!
+					}
+
+					type LibraryEdge {
+						node: Library!
+						cursor: String!
+					}
+
+					type Library {
+						name: String
+					}
+
+					type PageInfo {
+						hasPreviousPage: Boolean!
+						hasNextPage: Boolean!
+						startCursor: String
+						endCursor: String
+					}
+					""";
+
+			FieldCoordinates coordinates = FieldCoordinates.coordinates("Query", "libraries");
+			DataFetcher<?> dataFetcher = env -> null;
+
+			DataFetcher<?> actual =
+					applyConnectionFieldTypeVisitor(schemaContent, coordinates, dataFetcher);
+
+			assertThat(actual).isInstanceOf(ConnectionFieldTypeVisitor.ConnectionDataFetcher.class);
+		}
+
 		private static DataFetcher<?> applyConnectionFieldTypeVisitor(
 				Object schemaSource, FieldCoordinates coordinates, DataFetcher<?> fetcher) throws Exception {
 
@@ -290,8 +328,6 @@ public class ConnectionFieldTypeVisitorTests {
 			}
 		}
 	}
-
-
 
 	private static class ListConnectionAdapter implements ConnectionAdapter {
 


### PR DESCRIPTION
Optionally allow the edge type to be defined as non-null when validation the connection field type