### PR TITLE
Use correct logger name in QuerydslDataFetcher

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/query/QuerydslDataFetcher.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/query/QuerydslDataFetcher.java
@@ -106,7 +106,7 @@ import org.springframework.util.MultiValueMap;
  */
 public abstract class QuerydslDataFetcher<T> {
 
-	private static final Log logger = LogFactory.getLog(QueryByExampleDataFetcher.class);
+	private static final Log logger = LogFactory.getLog(QuerydslDataFetcher.class);
 
 	private static final QuerydslPredicateBuilder BUILDER = new QuerydslPredicateBuilder(
 			DefaultConversionService.getSharedInstance(), SimpleEntityPathResolver.INSTANCE);


### PR DESCRIPTION
Just a very tiny PR, because I stumbled over this while debugging.