### PR TITLE
Add toString() method in ArgumentValue

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/ArgumentValue.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/ArgumentValue.java
@@ -137,6 +137,23 @@ public final class ArgumentValue<T> {
 		return result;
 	}
 
+	/**
+	 * Returns a non-empty string representation of this {@code ArgumentValue}
+	 * suitable for debugging.
+	 *
+	 * @return the string representation of this instance
+	 */
+	@Override
+	public String toString() {
+		if (this.omitted) {
+			return "ArgumentValue.omitted";
+		}
+		if (this.value == null){
+			return "ArgumentValue.empty";
+		}
+		return "ArgumentValue[%s]".formatted(this.value);
+	}
+
 
 	/**
 	 * Static factory method for an argument value that was provided, even if

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/ArgumentValueTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/ArgumentValueTests.java
@@ -80,4 +80,18 @@ class ArgumentValueTests {
 		assertThat(called.get()).isFalse();
 	}
 
+	@Test
+	void toStringShouldReturnOmittedWhenOmitted() {
+		assertThat(ArgumentValue.omitted()).hasToString("ArgumentValue.omitted");
+	}
+
+	@Test
+	void toStringShouldReturnEmptyWhenNull() {
+		assertThat(ArgumentValue.ofNullable(null)).hasToString("ArgumentValue.empty");
+	}
+
+	@Test
+	void toStringShouldReturnValueWhenValue() {
+		assertThat(ArgumentValue.ofNullable("hello")).hasToString("ArgumentValue[hello]");
+	}
 }


### PR DESCRIPTION
Override `toString()` method in `ArgumentValue` class based upon the `java.util.Optional` implementation.

**Purpose**: 
The `ArgumentValue` class doesn't override `toString()` which makes logging and debugging quite tedious.

For example, if you define an input type for a graphql mutation with multiple properties wrapped in `ArgumentValue`:
```java
record MyInput(
  ArgumentValue<String> field1,
  ArgumentValue<String> field2,
  ArgumentValue<String> field3,
  // many more fields...
) {}
```

You would have to manually write a custom `toString()` method for `MyInput` because IDEs or Lombok are (afaik) not able to generate it properly.