### PR TITLE
Remove redundant ExecutionGraphQlRequest interface declaration

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/server/WebGraphQlRequest.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/WebGraphQlRequest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.graphql.ExecutionGraphQlRequest;
 import org.springframework.graphql.GraphQlRequest;
 import org.springframework.graphql.support.DefaultExecutionGraphQlRequest;
 import org.springframework.http.HttpCookie;
@@ -48,7 +47,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Rossen Stoyanchev
  * @since 1.0.0
  */
-public class WebGraphQlRequest extends DefaultExecutionGraphQlRequest implements ExecutionGraphQlRequest {
+public class WebGraphQlRequest extends DefaultExecutionGraphQlRequest {
 
 	private static final MultiValueMap<String, HttpCookie> EMPTY_COOKIES =
 			CollectionUtils.unmodifiableMultiValueMap(new LinkedMultiValueMap<>());


### PR DESCRIPTION
## What
Removes redundant `implements ExecutionGraphQlRequest` from `WebGraphQlRequest` class declaration.

## Why
`WebGraphQlRequest` extends `DefaultExecutionGraphQlRequest`, which already implements `ExecutionGraphQlRequest`. The explicit interface declaration was therefore redundant and has been removed to clean up the code.
