### PR TITLE
Exempt unresolvable federated entities from @EntityMapping checks

### DIFF
--- a/spring-graphql/src/test/resources/books/federation-schema.graphqls
+++ b/spring-graphql/src/test/resources/books/federation-schema.graphqls
@@ -1,10 +1,17 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@key", "@extends", "@external"] )
+
 type Book @key(fields: "id") @extends {
     id: ID! @external
     author: Author
+    publisher: Publisher
 }
 
 type Author {
     id: ID
     firstName: String
     lastName: String
+}
+
+type Publisher @key(fields: "id", resolvable: false) {
+    id: ID! @external
 }


### PR DESCRIPTION
Closes issue #1222. Updates check ensuring federated types have @EntityMapping to exempt entities with 'resolvable: false', since by definition those should not have an @EntityMapping.