### PR TITLE
Document OIDC authentication testing in HttpGraphQlTester

### DIFF
--- a/spring-graphql-docs/modules/ROOT/pages/testing.adoc
+++ b/spring-graphql-docs/modules/ROOT/pages/testing.adoc
@@ -91,6 +91,10 @@ existing `HttpSocketGraphQlTester` to create a new instance with customized sett
 
 include-code::HttpSetup[tag=executeRequests,indent=0]
 
+If you need to test with OIDC (OpenID Connect) authentication, you can use Spring Security's `mockOidcLogin()` to create a mock OIDC user:
+
+include-code::HttpSetup[tag=oidcAuthentication,indent=0]
+
 
 
 [[testing.websocketgraphqltester]]

--- a/spring-graphql-docs/src/main/java/org/springframework/graphql/docs/testing/httpgraphqltester/HttpSetup.java
+++ b/spring-graphql-docs/src/main/java/org/springframework/graphql/docs/testing/httpgraphqltester/HttpSetup.java
@@ -82,6 +82,32 @@ public class HttpSetup {
 		// end::executeRequests[]
 	}
 
+	void oidcAuthentication() {
+		// tag::oidcAuthentication[]
+		// Note: This requires spring-security-test dependency
+		WebTestClient client = WebTestClient.bindToServer()
+				.baseUrl("http://localhost:8080/graphql")
+				.build();
+
+		// The following code demonstrates how to use mockOidcLogin() with HttpGraphQlTester
+		// You need to add spring-security-test, spring-security-oauth2-client, and spring-security-oauth2-jose dependencies
+		/*
+		import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers;
+
+		HttpGraphQlTester tester = HttpGraphQlTester.create(
+			client.mutateWith(
+				SecurityMockServerConfigurers.mockOidcLogin()
+					.oidcUser(yourOidcUser())
+			)
+		);
+		*/
+
+		// For documentation purposes only, this is a simplified version
+		WebTestClient mutatedClient = client; // In real code, this would be client.mutateWith(mockOidcLogin().oidcUser(yourOidcUser()))
+		HttpGraphQlTester tester = HttpGraphQlTester.create(mutatedClient);
+		// end::oidcAuthentication[]
+	}
+
 	static class Configuration {
 
 	}


### PR DESCRIPTION
### Summary of Changes

This pull request documents the use of `mockOidcLogin` for testing OpenID Connect (OIDC) authentication in `HttpGraphQlTester`. It provides guidance on simulating authentication scenarios in the context of GraphQL HTTP testing. 

### Why
I don't know where to refer to write the test with OIDC.
If you're familiar with WebTestClient this will be immediately obvious, but many users may not be (I am, in fact).