### PR TITLE
Add singleElement() to GraphQlTester.EntityList

### DIFF
--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
@@ -655,6 +655,18 @@ final class DefaultGraphQlTester implements GraphQlTester {
 						getEntity().size() > size));
 				return this;
 			}
+
+			@Override
+			public Entity<E, ?> singleElement() {
+				this.hasSize(1);
+
+				E element = this.get().get(0);
+				@SuppressWarnings("unchecked")
+				Class<E> elementClass = (Class<E>) element.getClass();
+
+				return new DefaultPath(DefaultPath.this.basePath, DefaultPath.this.path + "[0]", DefaultPath.this.delegate)
+						.entity(elementClass);
+			}
 		}
 
 

--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/DefaultGraphQlTester.java
@@ -659,11 +659,9 @@ final class DefaultGraphQlTester implements GraphQlTester {
 			@Override
 			public Entity<E, ?> singleElement() {
 				this.hasSize(1);
-
 				E element = this.get().get(0);
 				@SuppressWarnings("unchecked")
 				Class<E> elementClass = (Class<E>) element.getClass();
-
 				return new DefaultPath(DefaultPath.this.basePath, DefaultPath.this.path + "[0]", DefaultPath.this.delegate)
 						.entity(elementClass);
 			}

--- a/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/GraphQlTester.java
+++ b/spring-graphql-test/src/main/java/org/springframework/graphql/test/tester/GraphQlTester.java
@@ -470,6 +470,13 @@ public interface GraphQlTester {
 		 */
 		EntityList<E> hasSizeGreaterThan(int size);
 
+		/**
+		 * Verify the list has a single element and return an {@code Entity} spec for it.
+		 * <p>This is a convenience method that combines {@link #hasSize(int) hasSize(1)}
+		 * with navigating to the first element in the list.
+		 * @return an {@code Entity} spec for the single element that allows further assertions
+		 */
+		Entity<E, ?> singleElement();
 	}
 
 	/**

--- a/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
+++ b/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
@@ -213,6 +213,35 @@ class GraphQlTesterTests extends GraphQlTesterTestSupport {
 				.containsExactly(han, leia);
 
 		assertThat(getActualRequestDocument()).contains(document);
+
+		assertThatThrownBy(() -> entityList.singleElement())
+				.as("Should have exactly one element")
+				.hasMessage("Expecting list " +
+							"[MovieCharacter[name='Han Solo'], MovieCharacter[name='Leia Organa']] " +
+							"at path 'me.friends' to have size == 1\n" +
+							"Request: document='{me {name, friends}}'");
+	}
+
+	@Test
+	void entityListWithOneElement() {
+
+		String document = "{me {name, friends}}";
+		getGraphQlService().setDataAsJson(document,
+				"{" +
+				"  \"me\":{" +
+				"      \"name\":\"Luke Skywalker\","
+				+ "    \"friends\":[{\"name\":\"Han Solo\"}]" +
+				"  }" +
+				"}");
+
+		GraphQlTester.Response response = graphQlTester().document(document).execute();
+
+		MovieCharacter han = MovieCharacter.create("Han Solo");
+
+		response.path("me.friends")
+				.entityList(MovieCharacter.class)
+				.singleElement()
+				.isEqualTo(han);
 	}
 
 	@Test

--- a/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
+++ b/spring-graphql-test/src/test/java/org/springframework/graphql/test/tester/GraphQlTesterTests.java
@@ -173,12 +173,14 @@ class GraphQlTesterTests extends GraphQlTesterTestSupport {
 
 		String document = "{me {name, friends}}";
 		getGraphQlService().setDataAsJson(document,
-				"{" +
-				"  \"me\":{" +
-				"      \"name\":\"Luke Skywalker\","
-				+ "    \"friends\":[{\"name\":\"Han Solo\"}, {\"name\":\"Leia Organa\"}]" +
-				"  }" +
-				"}");
+				"""
+						{
+							"me":{
+								"name":"Luke Skywalker",
+								"friends":[{"name":"Han Solo"}, {"name":"Leia Organa"}]
+							}
+						}
+						""");
 
 		GraphQlTester.Response response = graphQlTester().document(document).execute();
 
@@ -213,26 +215,45 @@ class GraphQlTesterTests extends GraphQlTesterTestSupport {
 				.containsExactly(han, leia);
 
 		assertThat(getActualRequestDocument()).contains(document);
-
-		assertThatThrownBy(() -> entityList.singleElement())
-				.as("Should have exactly one element")
-				.hasMessage("Expecting list " +
-							"[MovieCharacter[name='Han Solo'], MovieCharacter[name='Leia Organa']] " +
-							"at path 'me.friends' to have size == 1\n" +
-							"Request: document='{me {name, friends}}'");
 	}
 
 	@Test
-	void entityListWithOneElement() {
+	void singleElementShouldThrowWhenMultiple() {
 
 		String document = "{me {name, friends}}";
 		getGraphQlService().setDataAsJson(document,
-				"{" +
-				"  \"me\":{" +
-				"      \"name\":\"Luke Skywalker\","
-				+ "    \"friends\":[{\"name\":\"Han Solo\"}]" +
-				"  }" +
-				"}");
+				"""
+						{
+							"me":{
+								"name":"Luke Skywalker",
+								"friends":[{"name":"Han Solo"}, {"name":"Leia Organa"}]
+							}
+						}
+						""");
+
+		GraphQlTester.Response response = graphQlTester().document(document).execute();
+		GraphQlTester.EntityList<MovieCharacter> entityList = response.path("me.friends").entityList(MovieCharacter.class);
+		assertThatThrownBy(entityList::singleElement)
+				.as("Should have exactly one element")
+				.hasMessage("Expecting list " +
+						"[MovieCharacter[name='Han Solo'], MovieCharacter[name='Leia Organa']] " +
+						"at path 'me.friends' to have size == 1\n" +
+						"Request: document='{me {name, friends}}'");
+	}
+
+	@Test
+	void entityListWithSingleElement() {
+
+		String document = "{me {name, friends}}";
+		getGraphQlService().setDataAsJson(document,
+				"""
+						{
+						  "me":{
+						      "name":"Luke Skywalker",
+						    "friends":[{"name":"Han Solo"}]
+						  }
+						}
+						""");
 
 		GraphQlTester.Response response = graphQlTester().document(document).execute();
 


### PR DESCRIPTION
This PR adds `singleElement()`, a utility method to check for lists of size one, and return the `Entity` in the same statement.