### PR TITLE
Handle WebSocket messages after MVC session closed

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/server/webmvc/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/webmvc/GraphQlWebSocketHandler.java
@@ -246,10 +246,13 @@ public class GraphQlWebSocketHandler extends TextWebSocketHandler implements Sub
 	}
 
 	private void handleInternal(WebSocketSession session, TextMessage webSocketMessage) throws IOException {
+		SessionState state = this.sessionInfoMap.get(session.getId());
+		if (state == null) {
+			return;
+		}
 		GraphQlWebSocketMessage message = decode(webSocketMessage);
 		String id = message.getId();
 		Map<String, Object> payload = message.getPayload();
-		SessionState state = getSessionInfo(session);
 		switch (message.resolvedType()) {
 			case SUBSCRIBE -> {
 				if (!state.isConnectionInitialized()) {

--- a/spring-graphql/src/test/java/org/springframework/graphql/server/webmvc/GraphQlWebSocketHandlerTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/server/webmvc/GraphQlWebSocketHandlerTests.java
@@ -71,6 +71,7 @@ import org.springframework.web.socket.server.support.WebSocketHttpRequestHandler
 
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.mock;
 import static org.springframework.graphql.server.support.GraphQlWebSocketMessageType.CONNECTION_ACK;
 import static org.springframework.graphql.server.support.GraphQlWebSocketMessageType.PING;
@@ -271,6 +272,22 @@ class GraphQlWebSocketHandlerTests extends WebSocketHandlerTestSupport {
 
 		handler.afterConnectionClosed(this.session, closeStatus);
 		assertThat(called).isTrue();
+	}
+
+	@Test
+	void messageAfterConnectionClosed() throws Exception {
+		handle(this.handler, new TextMessage("{\"type\":\"connection_init\"}"));
+
+		StepVerifier.create(this.session.getOutput())
+				.consumeNextWith((message) -> assertMessageType(message, GraphQlWebSocketMessageType.CONNECTION_ACK))
+				.then(this.session::close)
+				.expectComplete()
+				.verify(TIMEOUT);
+
+		this.handler.afterConnectionClosed(this.session, CloseStatus.NORMAL);
+
+		assertThatNoException().isThrownBy(() ->
+				this.handler.handleTextMessage(this.session, new TextMessage("{\"type\":\"ping\"}")));
 	}
 
 	@Test


### PR DESCRIPTION
This PR updates the MVC `GraphQlWebSocketHandler` to ignore text messages received after the WebSocket session state has already been removed during connection close.

It also adds a regression test for a message received after `afterConnectionClosed`.

Closes gh-1449

Tests: `./gradlew :spring-graphql:test :spring-graphql:checkstyleMain :spring-graphql:checkstyleTest`