### PR TITLE
Add nested key entity support for GraphQL Federation

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/federation/EntitiesDataFetcher.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/federation/EntitiesDataFetcher.java
@@ -57,14 +57,17 @@ final class EntitiesDataFetcher implements DataFetcher<Mono<DataFetcherResult<Li
 
 	private final HandlerDataFetcherExceptionResolver exceptionResolver;
 
+	private final EntityKeyResolver entityKeyResolver;
+
 
 	EntitiesDataFetcher(
 			Map<String, EntityHandlerMethod> handlerMethods, Map<String, String> objectToInterfaceMap,
-			HandlerDataFetcherExceptionResolver resolver) {
+			HandlerDataFetcherExceptionResolver resolver, EntityKeyResolver entityKeyResolver) {
 
 		this.handlerMethods = new LinkedHashMap<>(handlerMethods);
 		this.objectToInterfaceMap = objectToInterfaceMap;
 		this.exceptionResolver = resolver;
+		this.entityKeyResolver = entityKeyResolver;
 	}
 
 
@@ -120,7 +123,7 @@ final class EntitiesDataFetcher implements DataFetcher<Mono<DataFetcherResult<Li
 			DataFetchingEnvironment environment, EntityHandlerMethod handlerMethod,
 			Map<String, Object> representation, int index) {
 
-		return handlerMethod.getEntity(environment, representation)
+		return handlerMethod.getEntity(environment, representation, this.entityKeyResolver)
 				.switchIfEmpty(Mono.error(new RepresentationNotResolvedException(representation, handlerMethod)))
 				.onErrorResume((ex) -> resolveException(ex, environment, handlerMethod, index));
 	}
@@ -141,7 +144,7 @@ final class EntitiesDataFetcher implements DataFetcher<Mono<DataFetcherResult<Li
 			}
 		}
 
-		return handlerMethod.getEntities(environment, typeRepresentations)
+		return handlerMethod.getEntities(environment, typeRepresentations, this.entityKeyResolver)
 				.mapNotNull((result) -> (((List<?>) result).isEmpty()) ? null : result)
 				.switchIfEmpty(Mono.defer(() -> {
 					List<Mono<?>> exceptions = new ArrayList<>(originalIndexes.size());

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/federation/EntityArgumentMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/federation/EntityArgumentMethodArgumentResolver.java
@@ -24,6 +24,7 @@ import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DelegatingDataFetchingEnvironment;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.beans.BeanUtils;
 import org.springframework.core.ResolvableType;
 import org.springframework.graphql.data.GraphQlArgumentBinder;
 import org.springframework.graphql.data.method.annotation.Argument;
@@ -68,9 +69,25 @@ final class EntityArgumentMethodArgumentResolver extends ArgumentMethodArgumentR
 	}
 
 	private @Nullable Object doBind(String name, ResolvableType targetType, Map<String, Object> entityMap) throws BindException {
-		Object rawValue = entityMap.get(name);
-		boolean isOmitted = !entityMap.containsKey(name);
-		return getArgumentBinder().bind(rawValue, isOmitted, targetType);
+		if (isScalarValue(entityMap)) {
+			Object rawValue = entityMap.get(name);
+			return getArgumentBinder().bind(rawValue, false, targetType);
+		}
+		return getArgumentBinder().bind(entityMap, false, targetType);
+	}
+
+	private boolean isScalarValue(Map<String, Object> entityMap) {
+		if (entityMap.size() != 2) {
+			return false;
+		}
+
+		for (Map.Entry<String, Object> entry : entityMap.entrySet()) {
+			if (!"__typename".equals(entry.getKey())) {
+				Object value = entry.getValue();
+				return BeanUtils.isSimpleValueType(value.getClass());
+			}
+		}
+		return false;
 	}
 
 	private static String dePluralize(String name) {

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/federation/EntityArgumentMethodArgumentResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/federation/EntityArgumentMethodArgumentResolver.java
@@ -24,7 +24,6 @@ import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DelegatingDataFetchingEnvironment;
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.beans.BeanUtils;
 import org.springframework.core.ResolvableType;
 import org.springframework.graphql.data.GraphQlArgumentBinder;
 import org.springframework.graphql.data.method.annotation.Argument;
@@ -52,14 +51,16 @@ final class EntityArgumentMethodArgumentResolver extends ArgumentMethodArgumentR
 			DataFetchingEnvironment environment, String name, ResolvableType targetType) throws BindException {
 
 		if (environment instanceof EntityDataFetchingEnvironment entityEnv) {
-			return doBind(name, targetType, entityEnv.getRepresentation());
+			Object key = entityEnv.getKey();
+			return doBind(name, targetType, key);
 		}
 		else if (environment instanceof EntityBatchDataFetchingEnvironment batchEnv) {
 			name = dePluralize(name);
 			targetType = targetType.getNested(2);
 			List<@Nullable Object> values = new ArrayList<>();
 			for (Map<String, Object> representation : batchEnv.getRepresentations()) {
-				values.add(doBind(name, targetType, representation));
+				Object key = batchEnv.getKey(representation);
+				values.add(doBind(name, targetType, key));
 			}
 			return values;
 		}
@@ -68,26 +69,8 @@ final class EntityArgumentMethodArgumentResolver extends ArgumentMethodArgumentR
 		}
 	}
 
-	private @Nullable Object doBind(String name, ResolvableType targetType, Map<String, Object> entityMap) throws BindException {
-		if (isScalarValue(entityMap)) {
-			Object rawValue = entityMap.get(name);
-			return getArgumentBinder().bind(rawValue, false, targetType);
-		}
-		return getArgumentBinder().bind(entityMap, false, targetType);
-	}
-
-	private boolean isScalarValue(Map<String, Object> entityMap) {
-		if (entityMap.size() != 2) {
-			return false;
-		}
-
-		for (Map.Entry<String, Object> entry : entityMap.entrySet()) {
-			if (!"__typename".equals(entry.getKey())) {
-				Object value = entry.getValue();
-				return BeanUtils.isSimpleValueType(value.getClass());
-			}
-		}
-		return false;
+	private @Nullable Object doBind(String name, ResolvableType targetType, Object key) throws BindException {
+		return getArgumentBinder().bind(key, false, targetType);
 	}
 
 	private static String dePluralize(String name) {
@@ -99,16 +82,16 @@ final class EntityArgumentMethodArgumentResolver extends ArgumentMethodArgumentR
 	 * Utility method for use from {@link EntityHandlerMethod} to make the entity
 	 * representation map available.
 	 */
-	static DataFetchingEnvironment wrap(DataFetchingEnvironment env, Map<String, Object> representation) {
-		return new EntityDataFetchingEnvironment(env, representation);
+	static DataFetchingEnvironment wrap(DataFetchingEnvironment env, Map<String, Object> representation, EntityKeyResolver resolver) {
+		return new EntityDataFetchingEnvironment(env, representation, resolver);
 	}
 
 	/**
 	 * Utility method for use from {@link EntityHandlerMethod} to make the list
 	 * of entity representation maps available.
 	 */
-	static DataFetchingEnvironment wrap(DataFetchingEnvironment env, List<Map<String, Object>> representations) {
-		return new EntityBatchDataFetchingEnvironment(env, representations);
+	static DataFetchingEnvironment wrap(DataFetchingEnvironment env, List<Map<String, Object>> representations, EntityKeyResolver resolver) {
+		return new EntityBatchDataFetchingEnvironment(env, representations, resolver);
 	}
 
 
@@ -118,14 +101,20 @@ final class EntityArgumentMethodArgumentResolver extends ArgumentMethodArgumentR
 	static class EntityDataFetchingEnvironment extends DelegatingDataFetchingEnvironment {
 
 		private final Map<String, Object> representation;
+		private final EntityKeyResolver resolver;
 
-		EntityDataFetchingEnvironment(DataFetchingEnvironment env, Map<String, Object> representation) {
+		EntityDataFetchingEnvironment(DataFetchingEnvironment env, Map<String, Object> representation, EntityKeyResolver resolver) {
 			super(env);
 			this.representation = representation;
+			this.resolver = resolver;
 		}
 
 		Map<String, Object> getRepresentation() {
 			return this.representation;
+		}
+
+		public Object getKey() {
+			return this.resolver.getKey(representation);
 		}
 	}
 
@@ -137,14 +126,20 @@ final class EntityArgumentMethodArgumentResolver extends ArgumentMethodArgumentR
 	static class EntityBatchDataFetchingEnvironment extends DelegatingDataFetchingEnvironment {
 
 		private final List<Map<String, Object>> representations;
+		private final EntityKeyResolver resolver;
 
-		EntityBatchDataFetchingEnvironment(DataFetchingEnvironment env, List<Map<String, Object>> representations) {
+		EntityBatchDataFetchingEnvironment(DataFetchingEnvironment env, List<Map<String, Object>> representations, EntityKeyResolver resolver) {
 			super(env);
 			this.representations = representations;
+			this.resolver = resolver;
 		}
 
 		List<Map<String, Object>> getRepresentations() {
 			return this.representations;
+		}
+
+		public Object getKey(Map<String, Object> representation) {
+			return this.resolver.getKey(representation);
 		}
 	}
 

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/federation/EntityHandlerMethod.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/federation/EntityHandlerMethod.java
@@ -52,13 +52,13 @@ final class EntityHandlerMethod extends DataFetcherHandlerMethodSupport {
 	}
 
 
-	Mono<Object> getEntity(DataFetchingEnvironment env, Map<String, Object> representation) {
-		env = EntityArgumentMethodArgumentResolver.wrap(env, representation);
+	Mono<Object> getEntity(DataFetchingEnvironment env, Map<String, Object> representation, EntityKeyResolver resolver) {
+		env = EntityArgumentMethodArgumentResolver.wrap(env, representation, resolver);
 		return doInvoke(env);
 	}
 
-	Mono<Object> getEntities(DataFetchingEnvironment env, List<Map<String, Object>> representations) {
-		env = EntityArgumentMethodArgumentResolver.wrap(env, representations);
+	Mono<Object> getEntities(DataFetchingEnvironment env, List<Map<String, Object>> representations, EntityKeyResolver resolver) {
+		env = EntityArgumentMethodArgumentResolver.wrap(env, representations, resolver);
 		return doInvoke(env);
 	}
 

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/federation/EntityKeyResolver.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/federation/EntityKeyResolver.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.graphql.data.federation;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import graphql.language.Argument;
+import graphql.language.Directive;
+import graphql.language.Document;
+import graphql.language.Field;
+import graphql.language.OperationDefinition;
+import graphql.language.SelectionSet;
+import graphql.language.StringValue;
+import graphql.language.TypeDefinition;
+import graphql.parser.Parser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+
+/**
+ * Resolves a simple entity key from a federated entity representation map.
+ * <p>This resolver inspects the GraphQL type definitions for {@code @key(fields: "...")} directives and records keys
+ * only when the directive declares exactly one top-level scalar field (for example {@code @key(fields: "id")}).
+ *
+ * <p>For matching types, {@link #getKey(Map)} returns the scalar key value from the representation.
+ * For all other types (composite keys, nested keys), it returns the full representation map.
+ *
+ * @author James Bodkin
+ * @since 2.0.5
+ */
+public class EntityKeyResolver {
+
+	private final Map<String, String> keyField = new LinkedHashMap<>();
+
+	EntityKeyResolver(TypeDefinitionRegistry registry) {
+		for (TypeDefinition<?> type : registry.types().values()) {
+			for (Directive directive : type.getDirectives("key")) {
+				processDirective(type, directive);
+			}
+		}
+	}
+
+	private void processDirective(TypeDefinition<?> type, Directive directive) {
+		Argument argument = directive.getArgument("fields");
+		if (argument != null) {
+			Object value = argument.getValue();
+			if (value instanceof StringValue sv) {
+				Parser parser = new Parser();
+				Document document = parser.parseDocument("{" + sv.getValue() + "}");
+				OperationDefinition operationDefinition = document.getDefinitionsOfType(OperationDefinition.class).get(0);
+				SelectionSet selectionSet = operationDefinition.getSelectionSet();
+				if (selectionSet.getSelections().size() > 1) {
+					return;
+				}
+
+				Field field = selectionSet.getSelectionsOfType(Field.class).get(0);
+				if (field.getSelectionSet() == null || field.getSelectionSet().getSelections().isEmpty()) {
+					this.keyField.put(type.getName(), field.getName());
+				}
+			}
+		}
+	}
+
+	/**
+	 * Resolve the entity key for a federated entity representation map.
+	 *
+	 * <p>If the representation type has a registered simple key field, this method returns that field value.
+	 * Otherwise, it returns the full representation as-is.
+	 * @param representation the federated entity representation map, expected to contain {@code __typename}
+	 * @return scalar key value for simple key entities, or the full representation map for complex key entities
+	 */
+	@SuppressWarnings("NullAway")
+	public Object getKey(Map<String, Object> representation) {
+		String typeName = (String) Objects.requireNonNull(representation.get("__typename"));
+		if (this.keyField.containsKey(typeName)) {
+			String fieldName = this.keyField.get(typeName);
+			return representation.get(fieldName);
+		}
+		else {
+			return representation;
+		}
+	}
+
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/federation/FederationSchemaFactory.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/federation/FederationSchemaFactory.java
@@ -188,8 +188,10 @@ public final class FederationSchemaFactory
 		Map<String, String> objectToInterfaceTypeMap = detectInterfaceImplementationTypes(registry);
 		checkEntityMappings(registry, objectToInterfaceTypeMap);
 
-		EntitiesDataFetcher entitiesDataFetcher =
-				new EntitiesDataFetcher(this.handlerMethods, objectToInterfaceTypeMap, getExceptionResolver());
+		EntityKeyResolver entityKeyResolver = new EntityKeyResolver(registry);
+
+		EntitiesDataFetcher entitiesDataFetcher = new EntitiesDataFetcher(this.handlerMethods, objectToInterfaceTypeMap,
+				getExceptionResolver(), entityKeyResolver);
 
 		return Federation.transform(registry, wiring)
 				.fetchEntities(entitiesDataFetcher)

--- a/spring-graphql/src/test/java/org/springframework/graphql/Library.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/Library.java
@@ -1,0 +1,4 @@
+package org.springframework.graphql;
+
+public record Library(String id, Location location) {
+}

--- a/spring-graphql/src/test/java/org/springframework/graphql/Library.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/Library.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.graphql;
 
 public record Library(String id, Location location) {

--- a/spring-graphql/src/test/java/org/springframework/graphql/LibraryId.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/LibraryId.java
@@ -1,0 +1,8 @@
+package org.springframework.graphql;
+
+public record LibraryId(String id, LocationId location) {
+
+    public record LocationId(String id) {
+    }
+
+}

--- a/spring-graphql/src/test/java/org/springframework/graphql/LibraryId.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/LibraryId.java
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2020-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.graphql;
 
 public record LibraryId(String id, LocationId location) {
 
-    public record LocationId(String id) {
-    }
+	public record LocationId(String id) {
+	}
 
 }

--- a/spring-graphql/src/test/java/org/springframework/graphql/Location.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/Location.java
@@ -1,0 +1,4 @@
+package org.springframework.graphql;
+
+public record Location(String id) {
+}

--- a/spring-graphql/src/test/java/org/springframework/graphql/Location.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/Location.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.graphql;
 
 public record Location(String id) {

--- a/spring-graphql/src/test/java/org/springframework/graphql/LocationArea.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/LocationArea.java
@@ -1,0 +1,4 @@
+package org.springframework.graphql;
+
+public record LocationArea(Location location) {
+}

--- a/spring-graphql/src/test/java/org/springframework/graphql/LocationArea.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/LocationArea.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.graphql;
 
 public record LocationArea(Location location) {

--- a/spring-graphql/src/test/java/org/springframework/graphql/LocationAreaId.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/LocationAreaId.java
@@ -1,0 +1,8 @@
+package org.springframework.graphql;
+
+public record LocationAreaId(LocationId location) {
+
+    public record LocationId(String id) {
+    }
+
+}

--- a/spring-graphql/src/test/java/org/springframework/graphql/LocationAreaId.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/LocationAreaId.java
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2020-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.graphql;
 
 public record LocationAreaId(LocationId location) {
 
-    public record LocationId(String id) {
-    }
+	public record LocationId(String id) {
+	}
 
 }

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/federation/EntityMappingInvocationTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/federation/EntityMappingInvocationTests.java
@@ -42,6 +42,11 @@ import org.springframework.graphql.BookSource;
 import org.springframework.graphql.ExecutionGraphQlRequest;
 import org.springframework.graphql.ExecutionGraphQlResponse;
 import org.springframework.graphql.GraphQlSetup;
+import org.springframework.graphql.Library;
+import org.springframework.graphql.LibraryId;
+import org.springframework.graphql.Location;
+import org.springframework.graphql.LocationArea;
+import org.springframework.graphql.LocationAreaId;
 import org.springframework.graphql.ResponseHelper;
 import org.springframework.graphql.TestExecutionGraphQlService;
 import org.springframework.graphql.TestExecutionRequest;
@@ -64,9 +69,9 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  */
 class EntityMappingInvocationTests {
 
-	private static final Resource federationSchema = new ClassPathResource("books/federation-schema.graphqls");
+	private static final Resource bookFederationSchema = new ClassPathResource("books/federation-schema.graphqls");
 
-	private static final String document = """
+	private static final String bookDocument = """
 			query Entities($representations: [_Any!]!) {
 				_entities(representations: $representations) {
 					...on Book {
@@ -81,6 +86,32 @@ class EntityMappingInvocationTests {
 			}
 			""";
 
+	private static final Resource libraryFederationSchema = new ClassPathResource("library/federation-schema.graphqls");
+
+	private static final String locationAreaDocument = """
+			query Entities($representations: [_Any!]!) {
+				_entities(representations: $representations) {
+					...on LocationArea {
+						location {
+							id
+						}
+					}
+				}
+			}
+			""";
+
+	private static final String libraryDocument = """
+			query Entities($representations: [_Any!]!) {
+				_entities(representations: $representations) {
+					...on Library {
+						id
+						location {
+							id
+						}
+					}
+				}
+			}
+			""";
 
 	@Test
 	void fetchEntities() {
@@ -90,7 +121,7 @@ class EntityMappingInvocationTests {
 						Map.of("__typename", "Book", "id", "5"),
 						Map.of("__typename", "PrintedMedia", "id", "42")));
 
-		ResponseHelper helper = executeWith(BookController.class, variables);
+		ResponseHelper helper = executeWith(BookController.class, bookFederationSchema, bookDocument, variables);
 
 		assertAuthor(0, "Joseph", "Heller", helper);
 		assertAuthor(1, "George", "Orwell", helper);
@@ -109,7 +140,7 @@ class EntityMappingInvocationTests {
 						Map.of("__typename", "Book", "id", "3"),
 						Map.of("__typename", "Book", "id", "5")));
 
-		ResponseHelper helper = executeWith(BookController.class, variables);
+		ResponseHelper helper = executeWith(BookController.class, bookFederationSchema, bookDocument, variables);
 
 		assertError(helper, 0, "BAD_REQUEST", "Missing \"__typename\" argument");
 		assertError(helper, 1, "INTERNAL_ERROR", "No entity fetcher");
@@ -124,9 +155,34 @@ class EntityMappingInvocationTests {
 	@Test // gh-1057
 	void fetchEntitiesWithEmptyList() {
 		Map<String, Object> vars = Map.of("representations", Collections.emptyList());
-		ResponseHelper helper = executeWith(BookController.class, vars);
+		ResponseHelper helper = executeWith(BookController.class, bookFederationSchema, bookDocument, vars);
 
 		assertThat(helper.toEntity("_entities.length()", Integer.class)).isEqualTo(0);
+	}
+
+	@Test
+	void fetchSingleNestedKeyEntity() {
+		Map<String, Object> variables = Map.of("representations", List.of(
+			Map.of("__typename", "LocationArea", "location", Map.of("id", "1"))
+		));
+
+		ResponseHelper helper = executeWith(LibraryController.class, libraryFederationSchema, locationAreaDocument, variables);
+
+		LocationArea locationArea = helper.toEntity("_entities[0]", LocationArea.class);
+		assertThat(locationArea.location().id()).isEqualTo("1");
+	}
+
+	@Test
+	void fetchMixedNestedKeyEntity() {
+		Map<String, Object> variables = Map.of("representations", List.of(
+				Map.of("__typename", "Library", "id", "1", "location", Map.of("id", "1"))
+		));
+
+		ResponseHelper helper = executeWith(LibraryController.class, libraryFederationSchema, libraryDocument, variables);
+
+		Library library = helper.toEntity("_entities[0]", Library.class);
+		assertThat(library.id()).isEqualTo("1");
+		assertThat(library.location().id()).isEqualTo("1");
 	}
 
 	@ValueSource(classes = {BookListController.class, BookFluxController.class})
@@ -140,7 +196,7 @@ class EntityMappingInvocationTests {
 						Map.of("__typename", "Book", "id", "42"),
 						Map.of("__typename", "Book", "id", "53")));
 
-		ResponseHelper helper = executeWith(controllerClass, variables);
+		ResponseHelper helper = executeWith(controllerClass, bookFederationSchema, bookDocument, variables);
 
 		assertAuthor(0, "George", "Orwell", helper);
 		assertAuthor(1, "Virginia", "Woolf", helper);
@@ -158,7 +214,7 @@ class EntityMappingInvocationTests {
 						Map.of("__typename", "Book", "id", "4"),
 						Map.of("__typename", "Book", "id", "5")));
 
-		ResponseHelper helper = executeWith(controllerClass, variables);
+		ResponseHelper helper = executeWith(controllerClass, bookFederationSchema, bookDocument, variables);
 
 		assertError(helper, 0, "BAD_REQUEST", "handled");
 		assertError(helper, 1, "BAD_REQUEST", "handled");
@@ -174,7 +230,7 @@ class EntityMappingInvocationTests {
 						Map.of("__typename", "Book", "id", "4"),
 						Map.of("__typename", "Book", "id", "5")));
 
-		ResponseHelper helper = executeWith(controllerClass, variables);
+		ResponseHelper helper = executeWith(controllerClass, bookFederationSchema, bookDocument, variables);
 
 		assertError(helper, 0, "INTERNAL_ERROR", "Entity fetcher returned null or completed empty");
 		assertError(helper, 1, "INTERNAL_ERROR", "Entity fetcher returned null or completed empty");
@@ -188,7 +244,7 @@ class EntityMappingInvocationTests {
 						Map.of("__typename", "Book", "id", "3"),
 						Map.of("__typename", "Book", "id", "5")));
 
-		ResponseHelper helper = executeWith(DataLoaderBookController.class, variables);
+		ResponseHelper helper = executeWith(DataLoaderBookController.class, bookFederationSchema, bookDocument, variables);
 
 		assertAuthor(0, "Joseph", "Heller", helper);
 		assertAuthor(1, "George", "Orwell", helper);
@@ -196,13 +252,15 @@ class EntityMappingInvocationTests {
 
 	@Test
 	void unmappedEntity() {
-		assertThatIllegalStateException().isThrownBy(() -> executeWith(EmptyController.class, Map.of()))
+		assertThatIllegalStateException().isThrownBy(() -> executeWith(EmptyController.class, bookFederationSchema, bookDocument, Map.of()))
 				.withMessage("Unmapped entity types: 'Media', 'PrintedMedia', 'Book'");
 	}
 
-	private static ResponseHelper executeWith(Class<?> controllerClass, Map<String, Object> variables) {
+	private static ResponseHelper executeWith(Class<?> controllerClass, Resource federationSchema, String document,
+											  Map<String, Object> variables) {
+
 		ExecutionGraphQlRequest request = TestExecutionRequest.forDocumentAndVars(document, variables);
-		Mono<ExecutionGraphQlResponse> responseMono = graphQlService(controllerClass).execute(request);
+		Mono<ExecutionGraphQlResponse> responseMono = graphQlService(controllerClass, federationSchema).execute(request);
 		return ResponseHelper.forResponse(responseMono);
 	}
 
@@ -220,7 +278,7 @@ class EntityMappingInvocationTests {
 		assertThat(helper.<Object>rawValue(path)).isNull();
 	}
 
-	private static TestExecutionGraphQlService graphQlService(Class<?> controllerClass) {
+	private static TestExecutionGraphQlService graphQlService(Class<?> controllerClass, Resource federationSchema) {
 		BatchLoaderRegistry registry = new DefaultBatchLoaderRegistry();
 
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
@@ -389,6 +447,38 @@ class EntityMappingInvocationTests {
 					.message(ex.getMessage())
 					.build();
 		}
+	}
+
+	@SuppressWarnings("unused")
+	@Controller
+	public static class LibraryController {
+
+		@EntityMapping
+		public @Nullable Library library(@Argument LibraryId id, Map<String, Object> map) {
+
+			assertThat(id.id()).isNotNull();
+			assertThat(id.location().id()).isNotNull();
+
+			assertThat(map).hasSize(3)
+					.containsEntry("__typename", "Library")
+					.containsEntry("id", "1")
+					.containsEntry("location", Map.of("id", "1"));
+
+			return new Library("1", new Location("1"));
+		}
+
+		@EntityMapping
+		public @Nullable LocationArea locationArea(@Argument LocationAreaId id, Map<String, Object> map) {
+
+			assertThat(id.location().id()).isNotNull();
+
+			assertThat(map).hasSize(2)
+					.containsEntry("__typename", "LocationArea")
+					.containsEntry("location", Map.of("id", "1"));
+
+			return new LocationArea(new Location("1"));
+		}
+
 	}
 
 }

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/federation/EntityMappingInvocationTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/federation/EntityMappingInvocationTests.java
@@ -256,9 +256,7 @@ class EntityMappingInvocationTests {
 				.withMessage("Unmapped entity types: 'Media', 'PrintedMedia', 'Book'");
 	}
 
-	private static ResponseHelper executeWith(Class<?> controllerClass, Resource federationSchema, String document,
-											  Map<String, Object> variables) {
-
+	private static ResponseHelper executeWith(Class<?> controllerClass, Resource federationSchema, String document, Map<String, Object> variables) {
 		ExecutionGraphQlRequest request = TestExecutionRequest.forDocumentAndVars(document, variables);
 		Mono<ExecutionGraphQlResponse> responseMono = graphQlService(controllerClass, federationSchema).execute(request);
 		return ResponseHelper.forResponse(responseMono);

--- a/spring-graphql/src/test/resources/library/federation-schema.graphqls
+++ b/spring-graphql/src/test/resources/library/federation-schema.graphqls
@@ -1,0 +1,14 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@key", "@extends", "@external"] )
+
+type Location {
+    id: ID!
+}
+
+type Library @key(fields: "id location { id }") {
+    id: ID!
+    location: Location!
+}
+
+type LocationArea @key(fields: "location { id }") {
+    location: Location!
+}


### PR DESCRIPTION
This pull request adds support for nested keys in GraphQL Federation when using the EntityMapping annotation. Additionally, isOmitted is always set to false for entity mapping, as the GraphQL Gateway will not send requests when the object is null