### PR TITLE
Register reflection hints for Relay pagination types

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/data/pagination/RelayPaginationRuntimeHints.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/pagination/RelayPaginationRuntimeHints.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.graphql.data.pagination;
+
+import graphql.relay.DefaultConnection;
+import graphql.relay.DefaultConnectionCursor;
+import graphql.relay.DefaultEdge;
+import graphql.relay.DefaultPageInfo;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+
+/**
+ * {@link RuntimeHintsRegistrar} that registers reflection hints for the
+ * {@code graphql-java} Relay implementation classes returned by
+ * {@link ConnectionFieldTypeVisitor}. {@code graphql-java}'s
+ * {@code PropertyFetchingImpl} reads {@code cursor}, {@code node},
+ * {@code edges}, {@code pageInfo}, {@code hasNextPage}, etc. reflectively,
+ * so without these hints relay edges and page info are serialized as {@code null}
+ * in a native image.
+ *
+ * @author Seonwoo Jung
+ */
+class RelayPaginationRuntimeHints implements RuntimeHintsRegistrar {
+
+	@Override
+	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+		hints.reflection()
+				.registerType(DefaultConnection.class, MemberCategory.INVOKE_PUBLIC_METHODS)
+				.registerType(DefaultConnectionCursor.class, MemberCategory.INVOKE_PUBLIC_METHODS)
+				.registerType(DefaultEdge.class, MemberCategory.INVOKE_PUBLIC_METHODS)
+				.registerType(DefaultPageInfo.class, MemberCategory.INVOKE_PUBLIC_METHODS);
+	}
+
+}

--- a/spring-graphql/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-graphql/src/main/resources/META-INF/spring/aot.factories
@@ -1,1 +1,2 @@
 org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor=org.springframework.graphql.data.method.annotation.support.SchemaMappingBeanFactoryInitializationAotProcessor
+org.springframework.aot.hint.RuntimeHintsRegistrar=org.springframework.graphql.data.pagination.RelayPaginationRuntimeHints

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/pagination/RelayPaginationRuntimeHintsTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/pagination/RelayPaginationRuntimeHintsTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.graphql.data.pagination;
+
+import graphql.relay.DefaultConnection;
+import graphql.relay.DefaultConnectionCursor;
+import graphql.relay.DefaultEdge;
+import graphql.relay.DefaultPageInfo;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.beans.factory.aot.AotServices;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link RelayPaginationRuntimeHints}.
+ *
+ * @author Seonwoo Jung
+ */
+class RelayPaginationRuntimeHintsTests {
+
+	private final RuntimeHints hints = new RuntimeHints();
+
+	@Test
+	void registrarIsRegisteredInAotFactories() {
+		assertThat(AotServices.factories(getClass().getClassLoader()).load(RuntimeHintsRegistrar.class))
+				.anyMatch(RelayPaginationRuntimeHints.class::isInstance);
+	}
+
+	@Test
+	void registersReflectionHintsForRelayTypes() {
+		new RelayPaginationRuntimeHints().registerHints(this.hints, getClass().getClassLoader());
+
+		assertThat(RuntimeHintsPredicates.reflection()
+				.onType(DefaultConnection.class)
+				.withMemberCategory(MemberCategory.INVOKE_PUBLIC_METHODS)).accepts(this.hints);
+		assertThat(RuntimeHintsPredicates.reflection()
+				.onType(DefaultConnectionCursor.class)
+				.withMemberCategory(MemberCategory.INVOKE_PUBLIC_METHODS)).accepts(this.hints);
+		assertThat(RuntimeHintsPredicates.reflection()
+				.onType(DefaultEdge.class)
+				.withMemberCategory(MemberCategory.INVOKE_PUBLIC_METHODS)).accepts(this.hints);
+		assertThat(RuntimeHintsPredicates.reflection()
+				.onType(DefaultPageInfo.class)
+				.withMemberCategory(MemberCategory.INVOKE_PUBLIC_METHODS)).accepts(this.hints);
+	}
+
+}


### PR DESCRIPTION
Fixes #1479

## Root cause

`graphql-java`'s `PropertyFetchingImpl` resolves Relay connection fields (`edges`, `node`, `cursor`, `pageInfo`, `hasNextPage`, `endCursor`, …) reflectively against whatever Java object the data fetcher returns. Spring for GraphQL wraps `Window`, `Slice`, and other backing containers into the concrete `graphql-java` types `DefaultConnection`, `DefaultConnectionCursor`, `DefaultEdge`, and `DefaultPageInfo` inside `ConnectionFieldTypeVisitor.ConnectionDataFetcher`.

The GraalVM reachability metadata that used to list those four classes for `graphql-java` has been dropped from recent versions of the published metadata. On the JVM the reflective lookup still works, but in a native image the getters are inaccessible and `PropertyFetchingImpl` falls back to `null`, so relay responses come back with empty `node`/`pageInfo` even though the data fetcher produced the correct objects. The reporter on #1479 confirmed that adding hints for these four types restores the expected behavior.

## Change

Adds `RelayPaginationRuntimeHints`, a `RuntimeHintsRegistrar` that registers `INVOKE_PUBLIC_METHODS` for the four `graphql.relay.Default*` types, and wires it through `META-INF/spring/aot.factories`. Since Spring for GraphQL is the component that surfaces these types to `graphql-java`, registering the hints here keeps the fix scoped to the situations where Spring actually creates them, rather than relying on upstream metadata to stay in sync.

The hint only covers public getters (`INVOKE_PUBLIC_METHODS`), matching what `PropertyFetchingImpl` actually uses; no constructor or field hints are needed because Spring instantiates these types directly.

## Test evidence

- New `RelayPaginationRuntimeHintsTests` covers two things:
  - the registrar is picked up via `META-INF/spring/aot.factories`
  - each of the four Relay types has the `INVOKE_PUBLIC_METHODS` hint registered
- `./gradlew :spring-graphql:test --tests "org.springframework.graphql.data.pagination.*"` passes (existing `ConnectionFieldTypeVisitorTests`, `Base64CursorEncoderTests`, plus the new tests, all green).
- `./gradlew :spring-graphql:checkstyleMain :spring-graphql:checkstyleTest` is clean.

## Verification done

1. **No in-flight PR.** `gh pr list --repo spring-projects/spring-graphql --search "relay native hints"` and a scan of the recent PR list show no open PR referencing this issue.
2. **No active claim.** Issue thread has 0 comments and no "working on it" notes.
3. **Code-focused.** Touches only Java source, a test class, and one line of `META-INF/spring/aot.factories`.
4. **Bug still present on `main`.** None of `DefaultConnection`/`DefaultConnectionCursor`/`DefaultEdge`/`DefaultPageInfo` appear in `spring-graphql/src/main/resources/META-INF/native-image/.../reflect-config.json`, and no existing `RuntimeHintsRegistrar` registers them — verified by `grep -r "DefaultConnection\|DefaultEdge\|DefaultPageInfo" spring-graphql/src/main/`.
5. **Not closed by an umbrella.** Issue is open with no linked PR.
6. **Impact check.** Issue contains a clear reproducer (Relay-style controller returning `Window` running in native image) and a precise root-cause trace through `graphql.schema.PropertyFetchingImpl`; the reporter verified the same fix in their own application.