### PR TITLE
Remove duplicated "the"

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/ExecutionGraphQlRequest.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/ExecutionGraphQlRequest.java
@@ -50,7 +50,7 @@ public interface ExecutionGraphQlRequest extends GraphQlRequest {
 	 * {@code UUID.randomUUID()}.
 	 * <li>On WebSocket, the id is set to the message id of the {@code "subscribe"}
 	 * message from the GraphQL over WebSocket protocol that is used to correlate
-	 * request and response messages on the the WebSocket.
+	 * request and response messages on the WebSocket.
 	 * </ul>
 	 * <p>To override this id, use {@link #executionId(ExecutionId)} or configure
 	 * {@link graphql.GraphQL} with an {@link graphql.execution.ExecutionIdProvider}.


### PR DESCRIPTION
This PR fixes a typo of "the the" to "the".