### PR TITLE
Match path before Content-Type in GraphQlRequestPredicates

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/server/webflux/GraphQlRequestPredicates.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/webflux/GraphQlRequestPredicates.java
@@ -97,10 +97,10 @@ public final class GraphQlRequestPredicates {
 
 		@Override
 		public boolean test(ServerRequest request) {
-			return httpMethodMatch(request, HttpMethod.POST)
+			return pathMatch(request, this.pattern)
+					&& httpMethodMatch(request, HttpMethod.POST)
 					&& contentTypeMatch(request, this.contentTypes)
-					&& acceptMatch(request, this.acceptedMediaTypes)
-					&& pathMatch(request, this.pattern);
+					&& acceptMatch(request, this.acceptedMediaTypes);
 		}
 
 		private static boolean httpMethodMatch(ServerRequest request, HttpMethod expected) {

--- a/spring-graphql/src/main/java/org/springframework/graphql/server/webmvc/GraphQlRequestPredicates.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/webmvc/GraphQlRequestPredicates.java
@@ -97,10 +97,10 @@ public final class GraphQlRequestPredicates {
 
 		@Override
 		public boolean test(ServerRequest request) {
-			return httpMethodMatch(request, HttpMethod.POST)
+			return pathMatch(request, this.pattern)
+					&& httpMethodMatch(request, HttpMethod.POST)
 					&& contentTypeMatch(request, this.contentTypes)
-					&& acceptMatch(request, this.acceptedMediaTypes)
-					&& pathMatch(request, this.pattern);
+					&& acceptMatch(request, this.acceptedMediaTypes);
 		}
 
 		private static boolean httpMethodMatch(ServerRequest request, HttpMethod expected) {

--- a/spring-graphql/src/test/java/org/springframework/graphql/server/webflux/GraphQlRequestPredicatesTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/server/webflux/GraphQlRequestPredicatesTests.java
@@ -105,6 +105,16 @@ class GraphQlRequestPredicatesTests {
 			assertThat(httpPredicate.test(serverRequest)).isFalse();
 		}
 
+		@Test // gh-1485
+		void shouldNotRejectRequestWithInvalidContentTypeOnDifferentPath() {
+			MockServerHttpRequest request = MockServerHttpRequest.post("/invalid")
+					.header(HttpHeaders.CONTENT_TYPE, "bogus")
+					.accept(MediaType.APPLICATION_JSON, MediaTypes.APPLICATION_GRAPHQL_RESPONSE)
+					.build();
+			ServerRequest serverRequest = ServerRequest.create(MockServerWebExchange.from(request), Collections.emptyList());
+			assertThat(httpPredicate.test(serverRequest)).isFalse();
+		}
+
 		@Test
 		void shouldRejectRequestWithInvalidContentType() {
 			ServerWebExchange exchange = createMatchingHttpExchange()

--- a/spring-graphql/src/test/java/org/springframework/graphql/server/webmvc/GraphQlRequestPredicatesTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/server/webmvc/GraphQlRequestPredicatesTests.java
@@ -104,6 +104,15 @@ class GraphQlRequestPredicatesTests {
 			assertThatThrownBy(() -> httpPredicate.test(request)).isInstanceOf(UnsupportedMediaTypeStatusException.class);
 		}
 
+		@Test // gh-1485
+		void shouldNotRejectRequestWithInvalidContentTypeOnDifferentPath() {
+			MockHttpServletRequest servletRequest = createMatchingHttpRequest();
+			servletRequest.setRequestURI("/invalid");
+			servletRequest.setContentType("bogus");
+			ServerRequest request = ServerRequest.create(servletRequest, List.of());
+			assertThat(httpPredicate.test(request)).isFalse();
+		}
+
 		@Test
 		void shouldRejectRequestWithIncompatibleAccept() {
 			MockHttpServletRequest request = createMatchingHttpRequest();


### PR DESCRIPTION
Fixes #1485

The GraphQL route predicates evaluate the request path **last**, after the method, Content-Type and Accept checks:

```java
return httpMethodMatch(request, HttpMethod.POST)
        && contentTypeMatch(request, this.contentTypes)
        && acceptMatch(request, this.acceptedMediaTypes)
        && pathMatch(request, this.pattern);
```

Since #1145, `contentTypeMatch` throws `UnsupportedMediaTypeStatusException` for an unparseable Content-Type. Because `RouterFunctionMapping` evaluates the predicate during handler lookup for every request, any POST anywhere in the application with a malformed Content-Type is answered 415 — even when it does not target the GraphQL endpoint at all (details and a real-world failure mode with Vaadin heartbeats in #1485).

This change evaluates `pathMatch` first, so requests to other paths are never affected by Content-Type or Accept parsing. The deliberate 415 from #1145 is unchanged for requests genuinely aimed at the GraphQL path — the existing `shouldRejectRequestWithInvalidContentType` test still passes. Applied to both the WebMvc and the WebFlux predicate variants, with a regression test each (`shouldNotRejectRequestWithInvalidContentTypeOnDifferentPath`, red against the previous ordering with exactly the `UnsupportedMediaTypeStatusException`, green with this change; all 40 tests in both `GraphQlRequestPredicatesTests` classes pass).
