### PR TITLE
Handle response for closed MVC WebSocket session

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/server/webmvc/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/webmvc/GraphQlWebSocketHandler.java
@@ -345,12 +345,6 @@ public class GraphQlWebSocketHandler extends TextWebSocketHandler implements Sub
 				.read(GraphQlWebSocketMessage.class, new HttpInputMessageAdapter(message));
 	}
 
-	private SessionState getSessionInfo(WebSocketSession session) {
-		SessionState info = this.sessionInfoMap.get(session.getId());
-		Assert.notNull(info, "No SessionInfo for " + session);
-		return info;
-	}
-
 	@SuppressWarnings("unchecked")
 	private Flux<TextMessage> handleResponse(WebSocketSession session, String id, WebGraphQlResponse response) {
 		if (logger.isDebugEnabled()) {
@@ -364,10 +358,15 @@ public class GraphQlWebSocketHandler extends TextWebSocketHandler implements Sub
 			responseFlux = Flux.from((Publisher<ExecutionResult>) response.getData())
 					.map(ExecutionResult::toSpecification)
 					.doOnSubscribe((subscription) -> {
-							Subscription prev = getSessionInfo(session).getSubscriptions().putIfAbsent(id, subscription);
-							if (prev != null) {
-								throw new SubscriptionExistsException();
-							}
+						SessionState state = this.sessionInfoMap.get(session.getId());
+						if (state == null) {
+							subscription.cancel();
+							return;
+						}
+						Subscription prev = state.getSubscriptions().putIfAbsent(id, subscription);
+						if (prev != null) {
+							throw new SubscriptionExistsException();
+						}
 					});
 		}
 		else {

--- a/spring-graphql/src/test/java/org/springframework/graphql/server/webmvc/GraphQlWebSocketHandlerTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/server/webmvc/GraphQlWebSocketHandlerTests.java
@@ -38,6 +38,7 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
 import reactor.test.StepVerifier;
 
 import org.springframework.aot.hint.RuntimeHints;
@@ -288,6 +289,25 @@ class GraphQlWebSocketHandlerTests extends WebSocketHandlerTestSupport {
 
 		assertThatNoException().isThrownBy(() ->
 				this.handler.handleTextMessage(this.session, new TextMessage("{\"type\":\"ping\"}")));
+	}
+
+	@Test // gh-1501
+	void responseAfterConnectionClosed() throws Exception {
+		Sinks.Empty<Void> responseDelay = Sinks.empty();
+		GraphQlWebSocketHandler handler = initWebSocketHandler(
+				(request, chain) -> chain.next(request).delayUntil((response) -> responseDelay.asMono()));
+
+		handle(handler, new TextMessage("{\"type\":\"connection_init\"}"), new TextMessage(BOOK_SUBSCRIPTION));
+		handler.afterConnectionClosed(this.session, CloseStatus.NORMAL);
+
+		assertThatNoException().isThrownBy(responseDelay::tryEmitEmpty);
+
+		assertThat(this.session.isOpen()).isTrue();
+		StepVerifier.create(this.session.getOutput())
+				.consumeNextWith((message) -> assertMessageType(message, GraphQlWebSocketMessageType.CONNECTION_ACK))
+				.then(this.session::close) // Complete output Flux
+				.expectComplete()
+				.verify(TIMEOUT);
 	}
 
 	@Test


### PR DESCRIPTION
Closes gh-1501

Follow-up to gh-1449 / #1451, which guarded the inbound message path against a session whose state has already been removed during connection close. The same race exists on the response path: if the session is closed while a `subscribe` request is still executing, the `doOnSubscribe` callback in `handleResponse` fails with `IllegalArgumentException: No SessionInfo for ...`, which is then logged at ERROR level as `Unresolved IllegalArgumentException for request id <id>`, and an error message send is attempted on the already-closed session.

This change looks up the session state non-assertively in `handleResponse` and, when the session state is already gone, cancels the response publisher instead of throwing. Cancellation (rather than an error or empty completion) is deliberate: the per-session send scheduler is disposed in `afterConnectionClosed`, so any terminal signal flowing through the `publishOn` would fail with `RejectedExecutionException: Scheduler unavailable`.

The `responseAfterConnectionClosed` test holds the response back with an interceptor until after `afterConnectionClosed`, and asserts the late response is silently dropped. It fails without the fix and passes with it.

On a high-traffic production subscription endpoint this signature accounts for roughly 44,000 ERROR logs per 7 days, proportional to normal client disconnect churn.
