### PR TITLE
Pass attributes to underlying RestClient

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/client/HttpSyncGraphQlTransport.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/client/HttpSyncGraphQlTransport.java
@@ -77,6 +77,11 @@ final class HttpSyncGraphQlTransport implements SyncGraphQlTransport {
 				.contentType(this.contentType)
 				.accept(MediaType.APPLICATION_JSON, MediaTypes.APPLICATION_GRAPHQL_RESPONSE)
 				.body(request.toMap())
+				.attributes((attributes) -> {
+					if (request instanceof ClientGraphQlRequest clientRequest) {
+						attributes.putAll(clientRequest.getAttributes());
+					}
+				})
 				.exchange((httpRequest, httpResponse) -> {
 					if (httpResponse.getStatusCode().equals(HttpStatus.OK)) {
 						return httpResponse.bodyTo(MAP_TYPE);

--- a/spring-graphql/src/test/java/org/springframework/graphql/client/HttpSyncGraphQlClientBuilderTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/client/HttpSyncGraphQlClientBuilderTests.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import graphql.ExecutionResultImpl;
 import org.jspecify.annotations.Nullable;
@@ -192,6 +193,27 @@ class HttpSyncGraphQlClientBuilderTests {
 	}
 
 	@Test
+	void attributes() {
+		HttpSyncGraphQlClient.Builder<?> builder = this.setup.initBuilder();
+
+		ConcurrentHashMap<String, Object> attributesFromRestClientRequest = new ConcurrentHashMap<>();
+
+		this.setup.getRestClientBuilder()
+			.requestInterceptor(((request, body, execution) -> {
+				attributesFromRestClientRequest.putAll(request.getAttributes());
+				return execution.execute(request, body);
+			}));
+
+		builder.url("/graphql-one")
+			.build()
+			.document(DOCUMENT)
+			.attribute("attribute-one", "1")
+			.executeSync();
+
+		assertThat(attributesFromRestClientRequest).containsEntry("attribute-one", "1");
+	}
+
+	@Test
 	void codecConfigurerRegistersJsonPathMappingProvider() {
 
 		TestJacksonJsonConverter testConverter = new TestJacksonJsonConverter();
@@ -221,6 +243,8 @@ class HttpSyncGraphQlClientBuilderTests {
 
 	private static class ClientBuilderSetup {
 
+		private RestClient.Builder restClientBuilder;
+
 		private final MockExecutionGraphQlService graphQlService = new MockExecutionGraphQlService();
 
 		@Nullable
@@ -242,7 +266,8 @@ class HttpSyncGraphQlClientBuilderTests {
 		public HttpSyncGraphQlClient.Builder<?> initBuilder() {
 			HttpHandler httpHandler = initServer();
 			ClientHttpRequestFactory requestFactory = new HttpHandlerClientHttpRequestFactory(httpHandler);
-			return HttpSyncGraphQlClient.builder(RestClient.builder().requestFactory(requestFactory));
+			restClientBuilder = RestClient.builder().requestFactory(requestFactory);
+			return HttpSyncGraphQlClient.builder(restClientBuilder);
 		}
 
 		private HttpHandler initServer() {
@@ -257,6 +282,9 @@ class HttpSyncGraphQlClientBuilderTests {
 			return RouterFunctions.toHttpHandler(routerFunction, HandlerStrategies.withDefaults());
 		}
 
+		RestClient.Builder getRestClientBuilder() {
+			return restClientBuilder;
+		}
 	}
 
 


### PR DESCRIPTION
This commit changes HttpSyncGraphQlTransport so that attributes set on ClientGraphQlRequest are sent to the underlying RestClientRequest when using a HttpSyncGraphQlClient backed by RestClient.

Closes gh-1509