### PR TITLE
Handle closed session when sending MVC WebSocket response

### DIFF
--- a/spring-graphql/src/main/java/org/springframework/graphql/server/webmvc/GraphQlWebSocketHandler.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/server/webmvc/GraphQlWebSocketHandler.java
@@ -739,7 +739,9 @@ public class GraphQlWebSocketHandler extends TextWebSocketHandler implements Sub
 				this.session.sendMessage(nextMessage);
 				request(1);
 			}
-			catch (IOException ex) {
+			catch (IOException | IllegalStateException ex) {
+				// IllegalStateException is raised (e.g. by Tomcat) when the session was
+				// concurrently closed while a response was still in flight.
 				cancel();
 				ExceptionWebSocketHandlerDecorator.tryCloseWithError(this.session, ex, logger);
 			}

--- a/spring-graphql/src/test/java/org/springframework/graphql/server/WebSocketHandlerTestSupport.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/server/WebSocketHandlerTestSupport.java
@@ -95,4 +95,22 @@ public abstract class WebSocketHandlerTestSupport {
 		}
 	}
 
+	public class ClosedSession extends TestWebSocketSession {
+
+		private final AtomicBoolean firstSent = new AtomicBoolean();
+
+		@Override
+		public void sendMessage(WebSocketMessage<?> message) throws IOException {
+			// Let the initial connection_ack through, then simulate the session being
+			// concurrently closed: Tomcat raises IllegalStateException (not IOException)
+			// on any subsequent send, e.g. while a subscription response is in flight.
+			if (this.firstSent.compareAndSet(false, true)) {
+				super.sendMessage(message);
+				return;
+			}
+			throw new IllegalStateException(
+					"Message will not be sent because the WebSocket session has been closed");
+		}
+	}
+
 }

--- a/spring-graphql/src/test/java/org/springframework/graphql/server/webmvc/GraphQlWebSocketHandlerTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/server/webmvc/GraphQlWebSocketHandlerTests.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -37,6 +38,7 @@ import jakarta.websocket.server.ServerContainer;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 import reactor.test.StepVerifier;
@@ -156,6 +158,37 @@ class GraphQlWebSocketHandlerTests extends WebSocketHandlerTestSupport {
 
 		StepVerifier.create(session.getOutput()).verifyComplete();
 		assertThat(SUBSCRIPTION_CANCELLED).isTrue();
+	}
+
+	@Test
+	void sessionClosedShouldCancelPublisher() throws Exception {
+		this.session = new ClosedSession();
+
+		// An IllegalStateException raised while sending a subscription response (e.g. by
+		// Tomcat when the session was concurrently closed) must be handled within
+		// SendMessageSubscriber like an IOException, rather than escaping hookOnNext to
+		// reactor's operator-error handling.
+		List<Throwable> operatorErrors = new CopyOnWriteArrayList<>();
+		Hooks.onOperatorError("gh-send-on-closed", (error, data) -> {
+			operatorErrors.add(error);
+			return error;
+		});
+		try {
+			handle(this.handler,
+					new TextMessage("{\"type\":\"connection_init\"}"), new TextMessage(BOOK_SUBSCRIPTION));
+
+			// The output Flux completes once the subscriber closes the session in response
+			// to the failed send; waiting on it also synchronizes with the send thread.
+			StepVerifier.create(session.getOutput())
+					.consumeNextWith((message) -> assertMessageType(message, CONNECTION_ACK))
+					.verifyComplete();
+
+			assertThat(operatorErrors).isEmpty();
+			assertThat(SUBSCRIPTION_CANCELLED).isTrue();
+		}
+		finally {
+			Hooks.resetOnOperatorError("gh-send-on-closed");
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

In the WebMVC `GraphQlWebSocketHandler`, `SendMessageSubscriber.hookOnNext` catches only `IOException` from `WebSocketSession.sendMessage`:

```java
try {
    this.session.sendMessage(nextMessage);
    request(1);
}
catch (IOException ex) {
    cancel();
    ExceptionWebSocketHandlerDecorator.tryCloseWithError(this.session, ex, logger);
}
```

When the WebSocket session is closed while a subscription response is still in flight, the servlet container does not raise `IOException` — Tomcat raises `IllegalStateException`:

```
java.lang.IllegalStateException: Message will not be sent because the WebSocket session has been closed
	at org.apache.tomcat.websocket.WsRemoteEndpointImplBase.writeMessagePart(WsRemoteEndpointImplBase.java:541)
	...
	at org.springframework.web.socket.adapter.standard.StandardWebSocketSession.sendTextMessage(StandardWebSocketSession.java:206)
	at org.springframework.web.socket.adapter.AbstractWebSocketSession.sendMessage(AbstractWebSocketSession.java:106)
	at org.springframework.graphql.server.webmvc.GraphQlWebSocketHandler$SendMessageSubscriber.hookOnNext(GraphQlWebSocketHandler.java:661)
	at reactor.core.publisher.BaseSubscriber.onNext(BaseSubscriber.java:163)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.runAsync(FluxPublishOn.java:448)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.run(FluxPublishOn.java:536)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:90)
	...
```

That `IllegalStateException` is not caught by the `catch (IOException ...)` clause, so instead of cancelling the response publisher and closing the session, it escapes `hookOnNext` and propagates on the serial send-scheduler thread (`publishOn`) as an uncaught error.

## Production impact

We are hitting this in production. On our WebSocket subscription gateway (WebMVC + Tomcat), session close during an in-flight subscription is entirely routine — clients navigate away, connections drop — and every such race produces this stack trace. It is one of our highest-volume framework errors on that service (on the order of ~100k occurrences/week, in steady state), pure noise that drowns out real errors and, depending on the Reactor version, is logged as an uncaught error on the scheduler thread rather than being handled cleanly.

## Fix

Handle `IllegalStateException` the same way as `IOException` in `hookOnNext` — cancel the response publisher and close the session with the error:

```java
catch (IOException | IllegalStateException ex) {
    // IllegalStateException is raised (e.g. by Tomcat) when the session was
    // concurrently closed while a response was still in flight.
    cancel();
    ExceptionWebSocketHandlerDecorator.tryCloseWithError(this.session, ex, logger);
}
```

## Test

Adds `sessionClosedShouldCancelPublisher` and a `ClosedSession` test fixture that lets the initial `connection_ack` through and then raises `IllegalStateException` on subsequent sends (simulating a session closed while a subscription response is in flight).

Note on observability: the reactor-core version used by the test suite wraps `hookOnNext` in `BaseSubscriber.onNext` and routes throwables to `onOperatorError`, which masks the escape at the handler-behaviour level. The regression test therefore asserts that the `IllegalStateException` is handled inside the subscriber and never reaches Reactor's `Hooks.onOperatorError` — this fails without the fix and passes with it.