### PR TITLE
Support interface projections for annotated controller return values

### DIFF
--- a/spring-graphql-docs/modules/ROOT/pages/controllers.adoc
+++ b/spring-graphql-docs/modules/ROOT/pages/controllers.adoc
@@ -335,6 +335,36 @@ If necessary, you can take over the mapping for individual subtypes:
 ----
 
 
+[[controllers.schema-mapping.return-projections]]
+=== Return Value Projections
+
+Add `@ProjectAs` to a `@SchemaMapping` method (including `@QueryMapping`, `@MutationMapping`,
+and `@SubscriptionMapping`) to adapt its return value to a Spring Data interface projection.
+This requires Spring Data Commons on the classpath and uses the same projection support as
+xref:data.adoc#data.projections[Spring Data repository data fetchers]. For example:
+
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+	@QueryMapping
+	@ProjectAs(BookView.class)
+	public Book bookById(@Argument Long id) {
+		return this.bookRepository.findById(id).orElse(null);
+	}
+
+	interface BookView {
+
+		@Value("#{target.name}")
+		String getTitle();
+	}
+----
+
+The projection applies to each element of a collection or asynchronous return value,
+including subscription events. `null` values remain `null`. For `DataFetcherResult`, only
+the data is projected; errors, extensions, and local context are preserved. Child schema
+mapping methods receive the projection as their source and should declare that interface
+as their source parameter type. `@ProjectAs` does not apply to `@BatchMapping` methods.
+
+
 [[controllers.schema-mapping.argument]]
 === `@Argument`
 

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/ProjectAs.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/ProjectAs.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.graphql.data.method.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Apply a Spring Data interface projection to the return value of a
+ * {@link SchemaMapping} method.
+ *
+ * <p>For collections and asynchronous return values, the projection is applied
+ * to each element. Requires Spring Data Commons on the classpath.
+ *
+ * @author Goutam Adwant
+ * @since 2.1.0
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ProjectAs {
+
+	/**
+	 * The projection interface to apply.
+	 */
+	Class<?> value();
+
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/AnnotatedControllerConfigurer.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/AnnotatedControllerConfigurer.java
@@ -69,6 +69,7 @@ import org.springframework.graphql.data.method.HandlerMethodArgumentResolver;
 import org.springframework.graphql.data.method.HandlerMethodArgumentResolverComposite;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.BatchMapping;
+import org.springframework.graphql.data.method.annotation.ProjectAs;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
 import org.springframework.graphql.data.pagination.CursorStrategy;
 import org.springframework.graphql.data.query.SortStrategy;
@@ -331,7 +332,7 @@ public class AnnotatedControllerConfigurer
 		if (!info.isBatchMapping()) {
 			dataFetcher = new SchemaMappingDataFetcher(
 					info, getArgumentResolvers(), this.validationHelper, getExceptionResolver(),
-					getExecutor(), shouldInvokeAsync(info.getHandlerMethod()));
+					getExecutor(), shouldInvokeAsync(info.getHandlerMethod()), obtainApplicationContext());
 		}
 		else {
 			dataFetcher = registerBatchLoader(info);
@@ -444,10 +445,12 @@ public class AnnotatedControllerConfigurer
 
 		private final boolean usesDataLoader;
 
+		private final @Nullable ReturnValueProjector returnValueProjector;
+
 		SchemaMappingDataFetcher(
 				DataFetcherMappingInfo info, HandlerMethodArgumentResolverComposite argumentResolvers,
 				@Nullable ValidationHelper helper, HandlerDataFetcherExceptionResolver exceptionResolver,
-				@Nullable Executor executor, boolean invokeAsync) {
+				@Nullable Executor executor, boolean invokeAsync, ApplicationContext applicationContext) {
 
 			this.mappingInfo = info;
 			this.argumentResolvers = argumentResolvers;
@@ -461,6 +464,10 @@ public class AnnotatedControllerConfigurer
 			this.invokeAsync = invokeAsync;
 			this.subscription = this.mappingInfo.getCoordinates().getTypeName().equalsIgnoreCase("Subscription");
 			this.usesDataLoader = hasDataLoaderParameter(info.getHandlerMethod());
+			ProjectAs annotation = info.getHandlerMethod().getMethodAnnotation(ProjectAs.class);
+			Assert.state(annotation == null || springDataPresent, "@ProjectAs requires Spring Data Commons");
+			this.returnValueProjector = (annotation != null) ?
+					new ReturnValueProjector(annotation.value(), applicationContext) : null;
 		}
 
 		private static boolean hasDataLoaderParameter(HandlerMethod method) {
@@ -479,7 +486,8 @@ public class AnnotatedControllerConfigurer
 
 		@Override
 		public ResolvableType getReturnType() {
-			return ResolvableType.forMethodReturnType(getHandlerMethod().getMethod());
+			ResolvableType type = ResolvableType.forMethodParameter(getHandlerMethod().getReturnType());
+			return (this.returnValueProjector != null) ? this.returnValueProjector.getReturnType(type) : type;
 		}
 
 		HandlerMethod getHandlerMethod() {
@@ -520,6 +528,9 @@ public class AnnotatedControllerConfigurer
 
 			try {
 				Object result = handlerMethod.invoke(environment);
+				if (this.returnValueProjector != null) {
+					result = this.returnValueProjector.project(result);
+				}
 				return applyExceptionHandling(environment, handlerMethod, result);
 			}
 			catch (Throwable ex) {

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ReturnValueProjector.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/ReturnValueProjector.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.graphql.data.method.annotation.support;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import graphql.execution.DataFetcherResult;
+import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.ReactiveAdapter;
+import org.springframework.core.ReactiveAdapterRegistry;
+import org.springframework.core.ResolvableType;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import org.springframework.graphql.execution.ReactiveAdapterRegistryHelper;
+import org.springframework.util.Assert;
+
+/**
+ * Applies an interface projection while preserving controller return value wrappers.
+ *
+ * @author Goutam Adwant
+ */
+final class ReturnValueProjector {
+
+	private final Class<?> projectionType;
+
+	private final SpelAwareProxyProjectionFactory projectionFactory = new SpelAwareProxyProjectionFactory();
+
+
+	ReturnValueProjector(Class<?> projectionType, ApplicationContext context) {
+		Assert.isTrue(projectionType.isInterface(), "@ProjectAs requires an interface projection type");
+		Assert.isTrue(!Iterable.class.isAssignableFrom(projectionType) && !Map.class.isAssignableFrom(projectionType),
+				"@ProjectAs requires a projection interface, not a container type");
+		this.projectionType = projectionType;
+		this.projectionFactory.setBeanFactory(context);
+		ClassLoader classLoader = context.getClassLoader();
+		if (classLoader != null) {
+			this.projectionFactory.setBeanClassLoader(classLoader);
+		}
+	}
+
+
+	@Nullable Object project(@Nullable Object result) {
+		result = ReactiveAdapterRegistryHelper.toMonoOrFluxIfReactive(result);
+		if (result instanceof Mono<?> mono) {
+			return mono.map((value) -> Objects.requireNonNull(project(value)));
+		}
+		if (result instanceof Flux<?> flux) {
+			return flux.map((value) -> Objects.requireNonNull(project(value)));
+		}
+		if (result instanceof DataFetcherResult<?> dataFetcherResult) {
+			return dataFetcherResult.map(this::project);
+		}
+		if (result instanceof Optional<?> optional) {
+			return optional.map(this::project);
+		}
+		if (result instanceof Iterable<?> iterable) {
+			List<@Nullable Object> values = new ArrayList<>();
+			iterable.forEach((value) -> values.add(project(value)));
+			return values;
+		}
+		if (result != null && result.getClass().isArray()) {
+			int length = Array.getLength(result);
+			List<@Nullable Object> values = new ArrayList<>(length);
+			for (int i = 0; i < length; i++) {
+				values.add(project(Array.get(result, i)));
+			}
+			return values;
+		}
+		return (result != null) ? this.projectionFactory.createProjection(this.projectionType, result) : null;
+	}
+
+	ResolvableType getReturnType(ResolvableType returnType) {
+		if (returnType.isArray()) {
+			return ResolvableType.forArrayComponent(getReturnType(returnType.getComponentType()));
+		}
+		Class<?> type = returnType.resolve(Object.class);
+		for (Class<?> wrapper : List.of(Iterable.class, Optional.class, Callable.class, DataFetcherResult.class)) {
+			if (wrapper.isAssignableFrom(type)) {
+				return ResolvableType.forClassWithGenerics(wrapper,
+						getReturnType(returnType.as(wrapper).getGeneric(0)));
+			}
+		}
+		ReactiveAdapter adapter = ReactiveAdapterRegistry.getSharedInstance().getAdapter(type);
+		if (adapter != null) {
+			return ResolvableType.forClassWithGenerics(adapter.isMultiValue() ? Flux.class : Mono.class,
+					getReturnType(returnType.as(adapter.getReactiveType()).getGeneric(0)));
+		}
+		return ResolvableType.forClass(this.projectionType);
+	}
+
+}

--- a/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/SchemaMappingBeanFactoryInitializationAotProcessor.java
+++ b/spring-graphql/src/main/java/org/springframework/graphql/data/method/annotation/support/SchemaMappingBeanFactoryInitializationAotProcessor.java
@@ -22,7 +22,10 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.springframework.aop.SpringProxy;
 import org.springframework.aot.generate.GenerationContext;
@@ -40,7 +43,11 @@ import org.springframework.beans.factory.support.RegisteredBean;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.core.DecoratingProxy;
 import org.springframework.core.MethodParameter;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.data.core.NullableWrapperConverters;
+import org.springframework.data.core.TypeInformation;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.projection.TargetAware;
 import org.springframework.graphql.data.ArgumentValue;
@@ -48,6 +55,7 @@ import org.springframework.graphql.data.method.HandlerMethodArgumentResolver;
 import org.springframework.graphql.data.method.HandlerMethodArgumentResolverComposite;
 import org.springframework.graphql.data.method.annotation.BatchMapping;
 import org.springframework.graphql.data.method.annotation.GraphQlExceptionHandler;
+import org.springframework.graphql.data.method.annotation.ProjectAs;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.ClassUtils;
@@ -193,8 +201,46 @@ class SchemaMappingBeanFactoryInitializationAotProcessor implements BeanFactoryI
 
 		private void processReturnType(RuntimeHints hints, MethodParameter parameter) {
 			new ArgumentBindingHints(parameter).apply(hints);
+			Method method = parameter.getMethod();
+			ProjectAs annotation = (method != null) ? AnnotatedElementUtils.findMergedAnnotation(method, ProjectAs.class) : null;
+			if (springDataPresent && annotation != null) {
+				registerProjectionHints(hints, annotation.value(), new HashSet<>());
+			}
 		}
 
+		private void registerProjectionHints(RuntimeHints hints, Class<?> type, Set<Class<?>> visited) {
+			if (!type.isInterface() || type.getName().startsWith("java.") || !visited.add(type)) {
+				return;
+			}
+			MethodParameterRuntimeHintsRegistrar.bindingRegistrar.registerReflectionHints(hints.reflection(), type);
+			hints.proxies().registerJdkProxy(type, TargetAware.class, SpringProxy.class, DecoratingProxy.class);
+			for (Method method : type.getMethods()) {
+				ResolvableType returnType = ResolvableType.forMethodReturnType(method, type);
+				registerProjectionPropertyHints(hints, returnType, visited);
+			}
+		}
+
+		private void registerProjectionPropertyHints(RuntimeHints hints, ResolvableType type, Set<Class<?>> visited) {
+			Class<?> resolved = type.resolve(Object.class);
+			if (type.isArray()) {
+				registerProjectionPropertyHints(hints, type.getComponentType(), visited);
+			}
+			else if (Iterable.class.isAssignableFrom(resolved)) {
+				registerProjectionPropertyHints(hints, type.as(Iterable.class).getGeneric(0), visited);
+			}
+			else if (Map.class.isAssignableFrom(resolved)) {
+				registerProjectionPropertyHints(hints, type.as(Map.class).getGeneric(1), visited);
+			}
+			else if (NullableWrapperConverters.supports(resolved)) {
+				TypeInformation<?> componentType = TypeInformation.of(type).getComponentType();
+				if (componentType != null) {
+					registerProjectionPropertyHints(hints, componentType.toResolvableType(), visited);
+				}
+			}
+			else {
+				registerProjectionHints(hints, resolved, visited);
+			}
+		}
 	}
 
 

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/SchemaMappingBeanFactoryInitializationAotProcessorTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/SchemaMappingBeanFactoryInitializationAotProcessorTests.java
@@ -20,6 +20,8 @@ import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
@@ -66,6 +68,7 @@ import org.springframework.graphql.data.method.annotation.ContextValue;
 import org.springframework.graphql.data.method.annotation.GraphQlExceptionHandler;
 import org.springframework.graphql.data.method.annotation.LocalContextValue;
 import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.ProjectAs;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
 import org.springframework.stereotype.Controller;
@@ -90,6 +93,61 @@ class SchemaMappingBeanFactoryInitializationAotProcessorTests {
 	void processorIsRegisteredInAotFactories() {
 		assertThat(AotServices.factories(getClass().getClassLoader()).load(BeanFactoryInitializationAotProcessor.class))
 				.anyMatch(SchemaMappingBeanFactoryInitializationAotProcessor.class::isInstance);
+	}
+
+	@Nested
+	class ReturnProjectionTests {
+
+		@Test
+		void registersProjectionAndNestedProjectionHints() {
+			processBeanClasses(ProjectionController.class);
+			assertThatHintsForJavaBeanBindingRegisteredForTypes(Book.class);
+			for (Class<?> projectionType : List.of(BookProjection.class, AuthorProjection.class, EditorProjection.class)) {
+				assertThat(RuntimeHintsPredicates.proxies().forInterfaces(
+						projectionType, TargetAware.class, SpringProxy.class, DecoratingProxy.class))
+						.accepts(generationContext.getRuntimeHints());
+			}
+			assertThatInvocationHintRegisteredForMethods(BookProjection.class, "getAuthors");
+			assertThatInvocationHintRegisteredForMethods(AuthorProjection.class, "getName", "getBook");
+			assertThatInvocationHintRegisteredForMethods(EditorProjection.class, "getName");
+		}
+
+		@Controller
+		static class ProjectionController {
+
+			@QueryMapping
+			@BookView
+			Book book() {
+				return null;
+			}
+		}
+
+		@Retention(RetentionPolicy.RUNTIME)
+		@ProjectAs(BookProjection.class)
+		@interface BookView {
+		}
+
+		interface BookProjection extends HasAuthors<AuthorProjection> {
+
+			com.google.common.base.Optional<EditorProjection> getEditor();
+		}
+
+		interface EditorProjection {
+
+			String getName();
+		}
+
+		interface HasAuthors<T> {
+
+			List<T> getAuthors();
+		}
+
+		interface AuthorProjection {
+
+			String getName();
+
+			BookProjection getBook();
+		}
 	}
 
 	@Nested

--- a/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/SchemaMappingProjectionTests.java
+++ b/spring-graphql/src/test/java/org/springframework/graphql/data/method/annotation/support/SchemaMappingProjectionTests.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.graphql.data.method.annotation.support;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
+import graphql.execution.DataFetcherResult;
+import graphql.schema.FieldCoordinates;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.graphql.GraphQlSetup;
+import org.springframework.graphql.data.method.annotation.GraphQlExceptionHandler;
+import org.springframework.graphql.data.method.annotation.ProjectAs;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.graphql.data.method.annotation.SchemaMapping;
+import org.springframework.graphql.data.method.annotation.SubscriptionMapping;
+import org.springframework.graphql.execution.SelfDescribingDataFetcher;
+import org.springframework.stereotype.Controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests for projected controller return values.
+ *
+ * @author Goutam Adwant
+ */
+class SchemaMappingProjectionTests {
+
+	private final AnnotationConfigApplicationContext context =
+			new AnnotationConfigApplicationContext(BookController.class);
+
+	@AfterEach
+	void closeContext() {
+		this.context.close();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"book", "mono", "future", "result"})
+	void scalarReturnValue(String field) {
+		ExecutionResult result = graphQl(field, "Book").execute("{ " + field + " { title } }");
+		assertThat(result.getErrors()).isEmpty();
+		assertThat(result.<Map<String, Object>>getData()).containsEntry(field, Map.of("title", "GraphQL"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"books", "array", "flux", "monoList", "bookFuture"})
+	void collectionReturnValue(String field) {
+		ExecutionResult result = graphQl(field, "[Book]").execute("{ " + field + " { title } }");
+		assertThat(result.getErrors()).isEmpty();
+		assertThat(result.<Map<String, Object>>getData()).containsEntry(field, List.of(Map.of("title", "GraphQL")));
+	}
+
+	@Test
+	void nullCollectionElement() {
+		ExecutionResult result = graphQl("nullableBooks", "[Book]").execute("{ nullableBooks { title } }");
+		assertThat(result.getErrors()).isEmpty();
+		assertThat(result.<Map<String, Object>>getData()).containsEntry("nullableBooks",
+				Arrays.asList(Map.of("title", "GraphQL"), null));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"nullBook", "emptyMono"})
+	void emptyReturnValue(String field) {
+		ExecutionResult result = graphQl(field, "Book").execute("{ " + field + " { title } }");
+		assertThat(result.getErrors()).isEmpty();
+		assertThat(result.<Map<String, Object>>getData()).containsEntry(field, null);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"failure", "monoFailure"})
+	void exceptionHandling(String field) {
+		ExecutionResult result = graphQl(field, "Book").execute("{ " + field + " { title } }");
+		assertThat(result.getErrors()).singleElement().extracting(GraphQLError::getMessage).isEqualTo("Expected failure");
+	}
+
+	@Test
+	void dataFetcherResultMetadataAndProjectedSource() {
+		ExecutionResult result = graphQl("result", "Book").execute("{ result { title description } }");
+		assertThat(result.getErrors()).isEmpty();
+		assertThat(result.<Map<String, Object>>getData()).containsEntry("result",
+				Map.of("title", "GraphQL", "description", "GraphQL"));
+		assertThat(result.getExtensions()).containsEntry("test", "value");
+	}
+
+	@Test
+	void callableReturnValue() throws Exception {
+		try (SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor()) {
+			AnnotatedControllerConfigurer configurer = configurer();
+			configurer.setExecutor(executor);
+			ExecutionResult result = setup("callable", "Book").runtimeWiring(configurer).toGraphQl()
+					.execute("{ callable { title } }");
+			assertThat(result.getErrors()).isEmpty();
+			assertThat(result.<Map<String, Object>>getData()).containsEntry("callable", Map.of("title", "GraphQL"));
+		}
+	}
+
+	@Test
+	void subscriptionReturnValue() {
+		GraphQL graphQl = GraphQlSetup.schemaContent("""
+				type Query { book: Book }
+				type Subscription { updates: Book }
+				type Book { title: String }
+				""").runtimeWiring(configurer()).toGraphQl();
+		ExecutionResult result = graphQl.execute("subscription { updates { title } }");
+		assertThat(result.getErrors()).isEmpty();
+		StepVerifier.create(result.<Publisher<ExecutionResult>>getData(), 1)
+				.assertNext((event) -> {
+					assertThat(event.getErrors()).isEmpty();
+					assertThat(event.<Map<String, Object>>getData()).containsEntry("updates", Map.of("title", "GraphQL"));
+				})
+				.thenCancel()
+				.verify();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"monoList", "bookFuture"})
+	void describesProjectionReturnType(String field) {
+		GraphQL graphQl = graphQl(field, "[Book]");
+		SelfDescribingDataFetcher<?> fetcher = (SelfDescribingDataFetcher<?>) graphQl.getGraphQLSchema()
+				.getCodeRegistry().getDataFetcher(FieldCoordinates.coordinates("Query", field),
+						graphQl.getGraphQLSchema().getQueryType().getFieldDefinition(field));
+		assertThat(fetcher.getReturnType().getGeneric(0, 0).resolve()).isEqualTo(BookProjection.class);
+	}
+
+	@ParameterizedTest
+	@ValueSource(classes = {int.class, List.class, Map.class})
+	void rejectsInvalidProjectionTargets(Class<?> type) {
+		assertThatIllegalArgumentException().isThrownBy(() -> new ReturnValueProjector(type, this.context));
+	}
+
+	@Test
+	void projectionTypeMustBeAnInterface() {
+		try (AnnotationConfigApplicationContext invalid = new AnnotationConfigApplicationContext(InvalidController.class)) {
+			assertThatIllegalArgumentException().isThrownBy(() -> setup("book", "Book")
+					.runtimeWiringForAnnotatedControllers(invalid).toGraphQl())
+					.withMessage("@ProjectAs requires an interface projection type");
+		}
+	}
+
+	private GraphQL graphQl(String field, String type) {
+		return setup(field, type).runtimeWiring(configurer()).toGraphQl();
+	}
+
+	private GraphQlSetup setup(String field, String type) {
+		return GraphQlSetup.schemaContent("type Query { " + field + ": " + type + " } " +
+				"type Book { title: String, description: String }");
+	}
+
+	private AnnotatedControllerConfigurer configurer() {
+		AnnotatedControllerConfigurer configurer = new AnnotatedControllerConfigurer();
+		configurer.setApplicationContext(this.context);
+		configurer.afterPropertiesSet();
+		return configurer;
+	}
+
+	@Controller
+	static class BookController {
+
+		@QueryMapping
+		@BookView
+		public Book book() {
+			return new Book("GraphQL");
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public Mono<Book> mono() {
+			return Mono.just(book());
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public CompletableFuture<Book> future() {
+			return CompletableFuture.completedFuture(book());
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public DataFetcherResult<Book> result() {
+			return DataFetcherResult.<Book>newResult().data(book()).localContext("context")
+					.extensions(Map.of("test", "value")).build();
+		}
+
+		@SchemaMapping(typeName = "Book")
+		public String description(BookProjection book) {
+			return book.getTitle();
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public Callable<Book> callable() {
+			return this::book;
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public List<Book> books() {
+			return List.of(book());
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public Book[] array() {
+			return new Book[] {book()};
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public Flux<Book> flux() {
+			return Flux.just(book());
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public Mono<List<Book>> monoList() {
+			return Mono.just(books());
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public BookFuture bookFuture() {
+			BookFuture future = new BookFuture();
+			future.complete(books());
+			return future;
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public List<Book> nullableBooks() {
+			return Arrays.asList(book(), null);
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public Book nullBook() {
+			return null;
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public Mono<Book> emptyMono() {
+			return Mono.empty();
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public Book failure() {
+			throw new IllegalStateException("Expected failure");
+		}
+
+		@QueryMapping
+		@ProjectAs(BookProjection.class)
+		public Mono<Book> monoFailure() {
+			return Mono.error(new IllegalStateException("Expected failure"));
+		}
+
+		@GraphQlExceptionHandler
+		public GraphQLError handle(IllegalStateException exception) {
+			return GraphqlErrorBuilder.newError().message(exception.getMessage()).build();
+		}
+
+		@SubscriptionMapping
+		@ProjectAs(BookProjection.class)
+		public Flux<Book> updates() {
+			return Flux.concat(Flux.just(book()), Flux.never());
+		}
+	}
+
+	@Controller
+	static class InvalidController {
+
+		@QueryMapping
+		@ProjectAs(String.class)
+		public Book book() {
+			return null;
+		}
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@ProjectAs(BookProjection.class)
+	@interface BookView {
+	}
+
+	interface BookProjection {
+
+		@Value("#{target.name}")
+		String getTitle();
+	}
+
+	static class BookFuture extends CompletableFuture<List<Book>> {
+	}
+
+	record Book(String name) {
+	}
+
+}

--- a/spring-graphql/src/test/kotlin/org/springframework/graphql/data/method/annotation/support/SchemaMappingProjectionKotlinTests.kt
+++ b/spring-graphql/src/test/kotlin/org/springframework/graphql/data/method/annotation/support/SchemaMappingProjectionKotlinTests.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.graphql.data.method.annotation.support
+
+import graphql.ExecutionResult
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.graphql.GraphQlSetup
+import org.springframework.graphql.data.method.annotation.ProjectAs
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.graphql.data.method.annotation.SubscriptionMapping
+import org.springframework.stereotype.Controller
+import reactor.test.StepVerifier
+
+/**
+ * Tests for projected coroutine controller return values.
+ *
+ * @author Goutam Adwant
+ */
+class SchemaMappingProjectionKotlinTests {
+
+	@Test
+	fun suspendingQuery() {
+		AnnotationConfigApplicationContext(BookController::class.java).use { context ->
+			val graphQl = GraphQlSetup.schemaContent("""
+				type Query { book: Book }
+				type Book { title: String }
+				""").runtimeWiringForAnnotatedControllers(context).toGraphQl()
+			val result = graphQl.execute("{ book { title } }")
+			assertThat(result.errors).isEmpty()
+			assertThat(result.getData<Map<String, Any>>()).containsEntry("book", mapOf("title" to "GraphQL"))
+		}
+	}
+
+	@Test
+	fun suspendingSubscription() {
+		AnnotationConfigApplicationContext(BookController::class.java).use { context ->
+			val graphQl = GraphQlSetup.schemaContent("""
+				type Query { book: Book }
+				type Subscription { updates: Book }
+				type Book { title: String }
+				""").runtimeWiringForAnnotatedControllers(context).toGraphQl()
+			val result = graphQl.execute("subscription { updates { title } }")
+			assertThat(result.errors).isEmpty()
+			StepVerifier.create(requireNotNull(result.getData<Publisher<ExecutionResult>>()))
+				.assertNext { event ->
+					assertThat(event.errors).isEmpty()
+					assertThat(event.getData<Map<String, Any>>()).containsEntry("updates", mapOf("title" to "GraphQL"))
+				}
+				.verifyComplete()
+		}
+	}
+
+	@Controller
+	class BookController {
+
+		@QueryMapping
+		@ProjectAs(BookProjection::class)
+		suspend fun book(): Book {
+			delay(1)
+			return Book("GraphQL")
+		}
+
+		@SubscriptionMapping
+		@ProjectAs(BookProjection::class)
+		suspend fun updates(): Flow<Book> = flow { emit(book()) }
+	}
+
+	interface BookProjection {
+
+		@Value("#{target.name}")
+		fun getTitle(): String
+	}
+
+	data class Book(val name: String)
+}


### PR DESCRIPTION
Annotated controllers currently require manual projection creation to expose a view of a domain object. Add @ProjectAs to select a Spring Data interface projection for a @SchemaMapping method, including query, mutation, and subscription mappings.

Apply projections to returned values and collection or asynchronous elements while preserving nulls, errors, and DataFetcherResult metadata. Include projected return-type information for schema inspection, nested projection proxy hints for AOT, and reference documentation. Spring Data Commons remains optional for controllers without the annotation.

Tests cover synchronous and asynchronous results, subscriptions, coroutine controllers, exception handling, projected child sources, invalid targets, and inherited/composed AOT projections.

Validation: the final controller, coroutine, and AOT suites pass (65 tests), together with fresh style and architecture checks. Broader default and Java 21 suites, run before the final two metadata corrections, had the same 10 existing MVC/WebFlux SSE whitespace assertion failures reproduced on unmodified main, plus 3 pre-existing skips.

Closes #657.